### PR TITLE
Update jvm.jl

### DIFF
--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -55,6 +55,10 @@ function findjvm()
         push!(javahomes, "/usr/lib/jvm/default-java/")
     end
 
+    if isdir("/usr/lib/jvm/")
+        push!(javahomes, "/usr/lib/jvm")
+    end
+
     push!(libpaths,pwd())
     for n in javahomes
         @static if is_windows()


### PR DESCRIPTION
On Linux systems that use alternatives (e.g. Fedora) the easiest way to lookup current libjvm.so is to use the currently configured Java runtime.