### PR TITLE
implement `convert` for `ArrayList`

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -162,6 +162,16 @@ end
 
 convert{X,Y}(::Type{@jimport(java.util.Map)}, K::Type{JavaObject{X}}, V::Type{JavaObject{Y}}, x::Dict) = convert(@jimport(java.util.Map), convert(@jimport(java.util.HashMap), K, V, x))
 
+function convert{X}(::Type{@jimport(java.util.ArrayList)}, x::Vector, V::Type{JavaObject{X}}=JObject)
+    ArrayList = @jimport(java.util.ArrayList)
+    a = ArrayList(())
+    for v in x
+        jcall(a, "add", jboolean, (JObject,), convert(V, v))
+    end
+    return a
+end
+
+convert{X}(::Type{@jimport(java.util.List)}, x::Vector, V::Type{JavaObject{X}}=JObject) = convert(@jimport(java.util.ArrayList), x, V)
 
 # Convert a reference to a java.lang.String into a Julia string. Copies the underlying byte buffer
 function unsafe_string(jstr::JString)  #jstr must be a jstring obtained via a JNI call

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,13 @@ a=@compat Dict("a"=>"A", "b"=>"B")
 b=convert(@jimport(java.util.Map), JString, JString, a)
 @assert jcall(b, "size", jint, ()) == 2
 
+# test for ArrayList conversion
+JArrayList = @jimport(java.util.ArrayList)
+p = JArrayList(())
+a = ["hello", " ", "world"]
+b = convert(@jimport(java.util.ArrayList), a, JString)
+@assert jcall(b, "size", jint, ()) == 3
+
 #Inner Classes
 TestInner = @jimport(Test$TestInner)
 Test = @jimport(Test)


### PR DESCRIPTION
Implement `convert` for `ArrayList` and `List` from Julia `Vector`.

It is similar to the existing methods for `HashTable` and `Map`. Except a default of `JObject` specified for the element type parameter.