### PR TITLE
class_for_name / Class.forName

### DIFF
--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -3,7 +3,7 @@ export JavaObject, JavaMetaClass,
        jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble,
        JObject, JClass, JMethod, JString,
        @jimport, jcall, jfield, isnull,
-       getname, listmethods, getreturntype, getparametertypes
+       getname, listmethods, getreturntype, getparametertypes, classforname
 
 using Base.Dates
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -82,6 +82,8 @@ isnull(obj::JavaMetaClass) = obj.ptr == C_NULL
 const JClass = JavaObject{Symbol("java.lang.Class")}
 const JObject = JavaObject{Symbol("java.lang.Object")}
 const JMethod = JavaObject{Symbol("java.lang.reflect.Method")}
+const JThread = JavaObject{Symbol("java.lang.Thread")}
+const JClassLoader = JavaObject{Symbol("java.lang.ClassLoader")}
 const JString = JavaObject{Symbol("java.lang.String")}
 
 function JString(str::AbstractString)

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -136,3 +136,23 @@ function Base.show(io::IO, method::JMethod)
     argtypestr = join(argtypes, ", ")
     print(io, "$rettype $name($argtypestr)")
 end
+
+
+"""
+```
+classforname(name::String)
+```
+Create an instance of `Class<name>` (same as `Class.forName(name)` in Java)
+
+### Args
+* name: The name of a class to instantiate
+
+### Returns
+JavaObject Instance of `Class<name>`
+"""
+function classforname(name::String)
+    thread = jcall(JThread, "currentThread", JThread, ())
+    loader = jcall(thread, "getContextClassLoader", JClassLoader, ())
+    return jcall(JClass, "forName", JClass, (JString, jboolean, JClassLoader),
+                 name, true, loader)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,5 +191,9 @@ for i in jcall(a, "iterator", @jimport(java.util.Iterator), ())
 end
 @test length(t) == 0
 
+
+JStringClass = classforname("java.lang.String")
+@test isa(JStringClass, JavaObject{Symbol("java.lang.Class")})
+
 # At the end, unload the JVM before exiting
 JavaCall.destroy()


### PR DESCRIPTION
Calling `Class.forName(name)` from JavaCall fails , most likely because default class loader doesn't respect a classpath, however calling `Class.forName(name, true, classLoader)` works fine. This PR provides a convenient wrapper function `class_for_name` for it.