### PR TITLE
A bit better iterator API

### DIFF
--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -3,7 +3,8 @@ export JavaObject, JavaMetaClass,
        jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble,
        JObject, JClass, JMethod, JString,
        @jimport, jcall, jfield, isnull,
-       getname, listmethods, getreturntype, getparametertypes, classforname
+       getname, getclass, listmethods, getreturntype, getparametertypes, classforname,
+       narrow
 
 using Base.Dates
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,7 +163,7 @@ jcall(a, "add", jboolean, (JObject,), "cde")
 jcall(a, "add", jboolean, (JObject,), "efg")
 
 t=Array{Any, 1}()
-for i in jcall(a, "iterator", @jimport(java.util.Iterator), ())
+for i in JavaCall.iterator(a)
 	push!(t, unsafe_string(i))
 end
 
@@ -186,14 +186,17 @@ end
 #Empty List
 a=JArrayList(())
 t=Array{Any, 1}()
-for i in jcall(a, "iterator", @jimport(java.util.Iterator), ())
+for i in JavaCall.iterator(a)
 	push!(t, unsafe_string(i))
 end
 @test length(t) == 0
 
-
 JStringClass = classforname("java.lang.String")
 @test isa(JStringClass, JavaObject{Symbol("java.lang.Class")})
+
+o = convert(JObject, "bla bla bla")
+@test isa(narrow(o), JString)
+
 
 # At the end, unload the JVM before exiting
 JavaCall.destroy()


### PR DESCRIPTION
Introduced 2 new functions: 

 * `iterator` - same as `collection.iterator()` in  Java
 * `narrow` - narrow type of a `JavaObject` to its actual class

`iterator` seems to be very generic, so not exporting it by default. `narrow` seems to be more specific, yet I'm not sure how much intuitive it is, so alternative names are welcome. 