### PR TITLE
listmethods() for types

### DIFF
--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -79,6 +79,16 @@ function listmethods(obj::JavaObject)
     jcall(cls, "getMethods", Vector{JMethod}, ())
 end
 
+function listmethods{C}(::Type{JavaObject{C}})
+    cls = classforname(string(C))
+    jcall(cls, "getMethods", Vector{JMethod}, ())
+end
+
+function listmethods(cls::JClass)
+    jcall(cls, "getMethods", Vector{JMethod}, ())
+end
+
+
 """
 ```
 listmethods(obj::JavaObject, name::AbstractString)
@@ -92,7 +102,7 @@ Lists the methods that are available on the java object passed. The methods are 
 ### Returns
 List of methods available on the java object and matching the name passed
 """
-function listmethods(obj::JavaObject, name::AbstractString)
+function listmethods{C}(obj::Union{JavaObject{C}, Type{JavaObject{C}}}, name::AbstractString)
     allmethods = listmethods(obj)
     filter(m -> getname(m) == name, allmethods)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,6 +142,12 @@ end
 
 @test length(listmethods(JString("test"))) >= 72
 @test length(listmethods(JString("test"), "indexOf")) >= 3
+# the same for the type
+@test length(listmethods(JString)) >= 72
+@test length(listmethods(JString, "indexOf")) >= 3
+# the same for class
+@test length(listmethods(getclass(JString("test")))) >= 72
+@test length(listmethods(getclass(JString("test")), "indexOf")) >= 3
 m = listmethods(JString("test"), "indexOf")[1]
 @test getname(getreturntype(m)) == "int"
 @test [getname(typ) for typ in getparametertypes(m)] == ["java.lang.String", "int"]


### PR DESCRIPTION
Currently we can do:

    listmethods(foo, "bar")

but not

    listmethods(JFoo, "bar")

This PR fixes it.