### PR TITLE
Compatibility with Java 9

### DIFF
--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -70,6 +70,7 @@ function findjvm()
              end
          end
         push!(libpaths, joinpath(n, "jre", "lib", "server"))
+        push!(libpaths, joinpath(n, "lib", "server"))
     end
 
     ext = @static is_windows()?"dll":(@static is_apple()?"dylib":"so")


### PR DESCRIPTION
On MacOS JDK-9 can be found on ${JAVA_HOME}/lib/server/