### PR TITLE
Updates for 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.5
+julia 0.6
 DataStructures
+Compat 0.65
 @windows WinReg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-    JAVA_HOME: C:\Program Files (x86)\Java\jdk1.7.0\
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-    JAVA_HOME: C:\Program Files\Java\jdk1.7.0\
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
     JAVA_HOME: C:\Program Files (x86)\Java\jdk1.7.0\
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
@@ -15,7 +11,6 @@ environment:
 
 matrix:
   allow_failures:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
 

--- a/doc/methods.md
+++ b/doc/methods.md
@@ -17,7 +17,7 @@ Currently, as a debugging aid, the module will print the location of the jvm lib
 The `JavaCall.init(args::Array{String, 1})` method must to used to load and initialise the Java Virtual Machine before any other functions in this module can be called. The `args` parameter is an array containing JVM initialisation arguments. This can be used to set, for example, the system classpath, and the maximum Java heap. Any valid commandline argument to the `java` command can be used. Unrecognised arguments are silently discarded. 
 
 ```julia
-JavaCall.init(["-Xmx512M", "-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))", "-verbose:jni", "-verbose:gc"])
+JavaCall.init(["-Xmx512M", "-Djava.class.path=$(@__DIR__)", "-verbose:jni", "-verbose:gc"])
 ```
 
 Note that only one JVM can be initialised within a process. Hence, the `init` function can be called only once per process. 

--- a/doc/push-gh-pages.jl
+++ b/doc/push-gh-pages.jl
@@ -1,6 +1,6 @@
 #Adapted from https://github.com/github/developer.github.com/blob/master/Rakefile#L21-L48
 
-cd(Pkg.dir()*"/JavaCall/doc")
+cd(@__DIR__)
 
 last_commit=readchomp(`git --no-pager log -1 --pretty=format:"%h:%s"`)
 
@@ -17,7 +17,7 @@ cd("_site") do
 	ENV["GIT_WORK_TREE"]=pwd()
 	run(`git add -A`)
 	tsha=chomp(readall(`git write-tree`))
-	mesg="Deploy docs for master@$last_commit" 
+	mesg="Deploy docs for master@$last_commit"
 
 	if length(old_sha) == 40
 	  	csha = chomp(readall(`git commit-tree $tsha -p $old_sha -m $(mesg)`))

--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -6,16 +6,26 @@ export JavaObject, JavaMetaClass,
        getname, getclass, listmethods, getreturntype, getparametertypes, classforname,
        narrow
 
-using Base.Dates
+using Compat, Compat.Dates
+
+using Compat.Sys: iswindows, islinux, isunix, isapple
 
 import DataStructures: OrderedSet
 
-@static if is_windows()
+if VERSION < v"0.7-"
+    using Compat: @warn, @error
+    import Base: isnull
+    Base.finalizer(f::Function, o) = Base.finalizer(o, f)
+else
+    using Libdl
+end
+
+@static if iswindows()
     using WinReg
 end
 
 
-import Base.convert, Base.isnull, Base.unsafe_convert, Base.unsafe_string
+import Base: convert, unsafe_convert, unsafe_string
 
 
 include("jnienv.jl")

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,33 +1,37 @@
-convert{T<:AbstractString}(::Type{JString}, str::T) = JString(str)
-convert{T<:AbstractString}(::Type{JObject}, str::T) = convert(JObject, JString(str))
+convert(::Type{JString}, str::AbstractString) = JString(str)
+convert(::Type{JObject}, str::AbstractString) = convert(JObject, JString(str))
 
 #Cast java object from S to T . Needed for polymorphic calls
-function convert{T,S}(::Type{JavaObject{T}}, obj::JavaObject{S})
+function convert(::Type{JavaObject{T}}, obj::JavaObject{S}) where {T,S}
     if isConvertible(T, S)   #Safe static cast
-        ptr = ccall(jnifunc.NewLocalRef, Ptr{Void}, (Ptr{JNIEnv}, Ptr{Void}), penv, obj.ptr)
-        if ptr === C_NULL geterror() end
+        ptr = ccall(jnifunc.NewLocalRef, Ptr{Nothing}, (Ptr{JNIEnv}, Ptr{Nothing}), penv, obj.ptr)
+        ptr === C_NULL && geterror()
         return JavaObject{T}(ptr)
     end
-    if isnull(obj) ; error("Cannot convert NULL"); end
-    realClass = ccall(jnifunc.GetObjectClass, Ptr{Void}, (Ptr{JNIEnv}, Ptr{Void} ), penv, obj.ptr)
+    isnull(obj) && @error("Cannot convert NULL")
+    realClass = ccall(jnifunc.GetObjectClass, Ptr{Nothing}, (Ptr{JNIEnv}, Ptr{Nothing} ), penv, obj.ptr)
     if isConvertible(T, realClass)  #dynamic cast
-        ptr = ccall(jnifunc.NewLocalRef, Ptr{Void}, (Ptr{JNIEnv}, Ptr{Void}), penv, obj.ptr)
-        if ptr === C_NULL geterror() end
+        ptr = ccall(jnifunc.NewLocalRef, Ptr{Nothing}, (Ptr{JNIEnv}, Ptr{Nothing}), penv, obj.ptr)
+        ptr === C_NULL && geterror()
         return JavaObject{T}(ptr)
     end
-    error("Cannot cast java object from $S to $T")
+    @error("Cannot cast java object from $S to $T")
 end
 
 #Is java type convertible from S to T.
-isConvertible(T, S) = (ccall(jnifunc.IsAssignableFrom, jboolean, (Ptr{JNIEnv}, Ptr{Void}, Ptr{Void}), penv, metaclass(S), metaclass(T) ) == JNI_TRUE)
-isConvertible(T, S::Ptr{Void} ) = (ccall(jnifunc.IsAssignableFrom, jboolean, (Ptr{JNIEnv}, Ptr{Void}, Ptr{Void}), penv, S, metaclass(T) ) == JNI_TRUE)
+isConvertible(T, S) = (ccall(jnifunc.IsAssignableFrom, jboolean,
+                             (Ptr{JNIEnv}, Ptr{Nothing}, Ptr{Nothing}), penv, metaclass(S),
+                             metaclass(T)) == JNI_TRUE)
+isConvertible(T, S::Ptr{Nothing}) = (ccall(jnifunc.IsAssignableFrom, jboolean,
+                                           (Ptr{JNIEnv}, Ptr{Nothing}, Ptr{Nothing}), penv, S,
+                                           metaclass(T)) == JNI_TRUE)
 
-unsafe_convert(::Type{Ptr{Void}}, cls::JavaMetaClass) = cls.ptr
+unsafe_convert(::Type{Ptr{Nothing}}, cls::JavaMetaClass) = cls.ptr
 
 # Get the JNI/C type for a particular Java type
 function real_jtype(rettype)
     if issubtype(rettype, JavaObject) || issubtype(rettype, Array) || issubtype(rettype, JavaMetaClass)
-        jnitype = Ptr{Void}
+        jnitype = Ptr{Nothing}
     else
         jnitype = rettype
     end
@@ -35,8 +39,8 @@ function real_jtype(rettype)
 end
 
 function convert_args(argtypes::Tuple, args...)
-    convertedArgs = Array{Int64}(length(args))
-    savedArgs = Array{Any}(length(args))
+    convertedArgs = Array{Int64}(undef, length(args))
+    savedArgs = Array{Any}(undef, length(args))
     for i in 1:length(args)
         r = convert_arg(argtypes[i], args[i])
         savedArgs[i] = r[1]
@@ -54,7 +58,7 @@ function convert_arg(argtype::Type, arg)
     x = convert(argtype, arg)
     return x,x
 end
-function convert_arg{T<:JavaObject}(argtype::Type{T}, arg)
+function convert_arg(argtype::Type{T}, arg) where T<:JavaObject
     x = convert(T, arg)::T
     return x, x.ptr
 end
@@ -71,30 +75,33 @@ for (x, y, z) in [ (:jboolean, :(jnifunc.NewBooleanArray), :(jnifunc.SetBooleanA
         function convert_arg(argtype::Type{Array{$x,1}}, arg)
             carg = convert(argtype, arg)
             sz=length(carg)
-            arrayptr = ccall($y, Ptr{Void}, (Ptr{JNIEnv}, jint), penv, sz)
-            ccall($z, Void, (Ptr{JNIEnv}, Ptr{Void}, jint, jint, Ptr{$x}), penv, arrayptr, 0, sz, carg)
+            arrayptr = ccall($y, Ptr{Nothing}, (Ptr{JNIEnv}, jint), penv, sz)
+            ccall($z, Nothing, (Ptr{JNIEnv}, Ptr{Nothing}, jint, jint, Ptr{$x}), penv, arrayptr, 0, sz,
+                  carg)
             return carg, arrayptr
         end
     end
     eval( m)
 end
 
-function convert_arg{T<:JavaObject}(argtype::Type{Array{T,1}}, arg)
+function convert_arg(argtype::Type{Array{T,1}}, arg) where T<:JavaObject
     carg = convert(argtype, arg)
-    sz=length(carg)
-    init=carg[1]
-    arrayptr = ccall(jnifunc.NewObjectArray, Ptr{Void}, (Ptr{JNIEnv}, jint, Ptr{Void}, Ptr{Void}), penv, sz, metaclass(T), init.ptr)
+    sz = length(carg)
+    init = carg[1]
+    arrayptr = ccall(jnifunc.NewObjectArray, Ptr{Nothing},
+                     (Ptr{JNIEnv}, jint, Ptr{Nothing}, Ptr{Nothing}), penv, sz, metaclass(T), init.ptr)
     for i=2:sz
-        ccall(jnifunc.SetObjectArrayElement, Void, (Ptr{JNIEnv}, Ptr{Void}, jint, Ptr{Void}), penv, arrayptr, i-1, carg[i].ptr)
+        ccall(jnifunc.SetObjectArrayElement, Nothing, (Ptr{JNIEnv}, Ptr{Nothing}, jint, Ptr{Nothing}),
+              penv, arrayptr, i-1, carg[i].ptr)
     end
     return carg, arrayptr
 end
 
-convert_result{T<:JString}(rettype::Type{T}, result) = unsafe_string(JString(result))
-convert_result{T<:JavaObject}(rettype::Type{T}, result) = T(result)
+convert_result(rettype::Type{T}, result) where {T<:JString} = unsafe_string(JString(result))
+convert_result(rettype::Type{T}, result) where {T<:JavaObject} = T(result)
 convert_result(rettype, result) = result
 
-for (x, y, z) in [ (:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.ReleaseBooleanArrayElements)),
+for (x, y, z) in [(:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.ReleaseBooleanArrayElements)),
                   (:jchar, :(jnifunc.GetCharArrayElements), :(jnifunc.ReleaseCharArrayElements)),
                   (:jbyte, :(jnifunc.GetByteArrayElements), :(jnifunc.ReleaseByteArrayElements)),
                   (:jshort, :(jnifunc.GetShortArrayElements), :(jnifunc.ReleaseShortArrayElements)),
@@ -102,13 +109,14 @@ for (x, y, z) in [ (:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.Rel
                   (:jlong, :(jnifunc.GetLongArrayElements), :(jnifunc.ReleaseLongArrayElements)),
                   (:jfloat, :(jnifunc.GetFloatArrayElements), :(jnifunc.ReleaseFloatArrayElements)),
                   (:jdouble, :(jnifunc.GetDoubleArrayElements), :(jnifunc.ReleaseDoubleArrayElements)) ]
-    m=quote
+    m = quote
         function convert_result(rettype::Type{Array{$(x),1}}, result)
-            sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, result)
-            arr = ccall($(y), Ptr{$(x)}, (Ptr{JNIEnv}, Ptr{Void}, Ptr{jboolean} ), penv, result, C_NULL )
-            jl_arr::Array = unsafe_wrap(Array, arr, Int(sz), false)
+            sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, result)
+            arr = ccall($(y), Ptr{$(x)}, (Ptr{JNIEnv}, Ptr{Nothing}, Ptr{jboolean} ), penv, result,
+                        C_NULL)
+            jl_arr::Array = unsafe_wrap(Array, arr, Int(sz))
             jl_arr = deepcopy(jl_arr)
-            ccall($(z), Void, (Ptr{JNIEnv},Ptr{Void}, Ptr{$(x)}, jint), penv, result, arr, 0)
+            ccall($(z), Nothing, (Ptr{JNIEnv},Ptr{Nothing}, Ptr{$(x)}, jint), penv, result, arr, 0)
             return jl_arr
         end
     end
@@ -116,13 +124,14 @@ for (x, y, z) in [ (:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.Rel
 end
 
 
-function convert_result{T}(rettype::Type{Array{JavaObject{T},1}}, result)
-    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, result)
+function convert_result(rettype::Type{Array{JavaObject{T},1}}, result) where T
+    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, result)
 
-    ret = Array{JavaObject{T}}(sz)
+    ret = Array{JavaObject{T}}(undef, sz)
 
     for i=1:sz
-        a=ccall(jnifunc.GetObjectArrayElement, Ptr{Void}, (Ptr{JNIEnv},Ptr{Void}, jint), penv, result, i-1)
+        a = ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing}, (Ptr{JNIEnv},Ptr{Nothing}, jint), penv,
+                  result, i-1)
         ret[i] = JavaObject{T}(a)
     end
     return ret
@@ -130,34 +139,37 @@ end
 
 
 # covers return types like Vector{Vector{T}}
-function convert_result{T}(rettype::Type{Array{T,1}}, result)
-    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, result)
+function convert_result(rettype::Type{Array{T,1}}, result) where T
+    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, result)
 
-    ret = Array{T}(sz)
+    ret = Array{T}(undef, sz)
 
     for i=1:sz
-        a=ccall(jnifunc.GetObjectArrayElement, Ptr{Void}, (Ptr{JNIEnv},Ptr{Void}, jint), penv, result, i-1)
+        a=ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing}, (Ptr{JNIEnv},Ptr{Nothing}, jint), penv, result, i-1)
         ret[i] = convert_result(T, a)
     end
     return ret
 end
 
 
-function convert_result{T}(rettype::Type{Array{JavaObject{T},2}}, result)
-    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, result)
+function convert_result(rettype::Type{Array{JavaObject{T},2}}, result) where T
+    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, result)
     if sz == 0
-        return Array{T}(0,0)
+        return Array{T}(undef, 0,0)
     end
-    a_1 = ccall(jnifunc.GetObjectArrayElement, Ptr{Void}, (Ptr{JNIEnv},Ptr{Void}, jint), penv, result, 0)
-    sz_1 = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, a_1)
-    ret = Array{JavaObject{T}}(sz, sz_1)
+    a_1 = ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing}, (Ptr{JNIEnv},Ptr{Nothing}, jint), penv,
+                result, 0)
+    sz_1 = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, a_1)
+    ret = Array{JavaObject{T}}(undef, sz, sz_1)
     for i=1:sz
-        a = ccall(jnifunc.GetObjectArrayElement, Ptr{Void}, (Ptr{JNIEnv},Ptr{Void}, jint), penv, result, i-1)
+        a = ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing}, (Ptr{JNIEnv},Ptr{Nothing}, jint), penv,
+                  result, i-1)
         # check that size of the current subarray is the same as for the first one
-        sz_a = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, a)
+        sz_a = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, a)
         @assert(sz_a == sz_1, "Size of $(i)th subrarray is $sz_a, but size of the 1st subarray was $sz_1")
         for j=1:sz_1
-            x = ccall(jnifunc.GetObjectArrayElement, Ptr{Void}, (Ptr{JNIEnv},Ptr{Void}, jint), penv, a, j-1)
+            x = ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing}, (Ptr{JNIEnv},Ptr{Nothing}, jint),
+                      penv, a, j-1)
             ret[i, j] = JavaObject{T}(x)
         end
     end
@@ -166,18 +178,20 @@ end
 
 
 # matrices of primitive types and other arrays
-function convert_result{T}(rettype::Type{Array{T,2}}, result)
-    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, result)
+function convert_result(rettype::Type{Array{T,2}}, result) where T
+    sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, result)
     if sz == 0
-        return Array{T}(0,0)
+        return Array{T}(undef, 0,0)
     end
-    a_1 = ccall(jnifunc.GetObjectArrayElement, Ptr{Void}, (Ptr{JNIEnv},Ptr{Void}, jint), penv, result, 0)
-    sz_1 = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, a_1)
-    ret = Array{T}(sz, sz_1)
-    for i=1:sz        
-        a = ccall(jnifunc.GetObjectArrayElement, Ptr{Void}, (Ptr{JNIEnv},Ptr{Void}, jint), penv, result, i-1)
+    a_1 = ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing}, (Ptr{JNIEnv},Ptr{Nothing}, jint), penv,
+                result, 0)
+    sz_1 = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, a_1)
+    ret = Array{T}(undef, sz, sz_1)
+    for i=1:sz
+        a = ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing}, (Ptr{JNIEnv},Ptr{Nothing}, jint), penv,
+                  result, i-1)
         # check that size of the current subarray is the same as for the first one
-        sz_a = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, a)
+        sz_a = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, a)
         @assert(sz_a == sz_1, "Size of $(i)th subrarray is $sz_a, but size of the 1st subarray was $sz_1")
         ret[i, :] = convert_result(Vector{T}, a)
     end
@@ -193,12 +207,17 @@ convert(::Type{jboolean}, obj::JavaObject{Symbol("java.lang.Boolean")}) = jcall(
 
 
 #The second term in this addition is due to the fact that Java converts all times to local time
-convert(::Type{DateTime}, x::@jimport(java.util.Date)) = isnull(x)?Dates.DateTime(1970,1,1,0,0,0):
-            (Dates.unix2datetime(jcall(x, "getTime", jlong, ())/1000) +
-                    Second(round(div(Dates.value(now() - now(Dates.UTC)),1000)/900)*(900)))
+function convert(::Type{DateTime}, x::@jimport(java.util.Date))
+    if isnull(x)
+        Dates.DateTime(1970,1,1,0,0,0)
+    else
+        Dates.unix2datetime(jcall(x, "getTime", jlong, ())/1000) +
+            Second(round(div(Dates.value(now() - now(Dates.UTC)),1000)/900)*(900))
+    end
+end
 
 function convert(::Type{DateTime}, x::JavaObject)
-    if isnull(x); return Dates.DateTime(1970,1,1,0,0,0); end
+    isnull(x) && return Dates.DateTime(1970,1,1,0,0,0)
     JDate = @jimport(java.util.Date)
     if isConvertible(JDate, x)
         return convert(DateTime, convert(JDate, x))
@@ -216,7 +235,8 @@ function convert(::Type{@jimport(java.util.Properties)}, x::Dict)
     return p
 end
 
-function convert{X,Y}(::Type{@jimport(java.util.HashMap)}, K::Type{JavaObject{X}}, V::Type{JavaObject{Y}}, x::Dict)
+function convert(::Type{@jimport(java.util.HashMap)}, K::Type{JavaObject{X}}, V::Type{JavaObject{Y}},
+                 x::Dict) where {X,Y}
     Hashmap = @jimport(java.util.HashMap)
     p = Hashmap(())
     for (n,v) in x
@@ -225,9 +245,12 @@ function convert{X,Y}(::Type{@jimport(java.util.HashMap)}, K::Type{JavaObject{X}
     return p
 end
 
-convert{X,Y}(::Type{@jimport(java.util.Map)}, K::Type{JavaObject{X}}, V::Type{JavaObject{Y}}, x::Dict) = convert(@jimport(java.util.Map), convert(@jimport(java.util.HashMap), K, V, x))
+function convert(::Type{@jimport(java.util.Map)}, K::Type{JavaObject{X}}, V::Type{JavaObject{Y}},
+                 x::Dict) where {X,Y}
+    convert(@jimport(java.util.Map), convert(@jimport(java.util.HashMap), K, V, x))
+end
 
-function convert{X}(::Type{@jimport(java.util.ArrayList)}, x::Vector, V::Type{JavaObject{X}}=JObject)
+function convert(::Type{@jimport(java.util.ArrayList)}, x::Vector, V::Type{JavaObject{X}}=JObject) where X
     ArrayList = @jimport(java.util.ArrayList)
     a = ArrayList(())
     for v in x
@@ -236,19 +259,23 @@ function convert{X}(::Type{@jimport(java.util.ArrayList)}, x::Vector, V::Type{Ja
     return a
 end
 
-convert{X}(::Type{@jimport(java.util.List)}, x::Vector, V::Type{JavaObject{X}}=JObject) = convert(@jimport(java.util.ArrayList), x, V)
+function convert(::Type{@jimport(java.util.List)}, x::Vector, V::Type{JavaObject{X}}=JObject) where X
+    convert(@jimport(java.util.ArrayList), x, V)
+end
 
 # Convert a reference to a java.lang.String into a Julia string. Copies the underlying byte buffer
 function unsafe_string(jstr::JString)  #jstr must be a jstring obtained via a JNI call
     if isnull(jstr); return ""; end #Return empty string to keep type stability. But this is questionable
-    pIsCopy = Array{jboolean}(1)
-    buf::Ptr{UInt8} = ccall(jnifunc.GetStringUTFChars, Ptr{UInt8}, (Ptr{JNIEnv}, Ptr{Void}, Ptr{jboolean}), penv, jstr.ptr, pIsCopy)
-    s=unsafe_string(buf)
-    ccall(jnifunc.ReleaseStringUTFChars, Void, (Ptr{JNIEnv}, Ptr{Void}, Ptr{UInt8}), penv, jstr.ptr, buf)
+    pIsCopy = Array{jboolean}(undef, 1)
+    buf::Ptr{UInt8} = ccall(jnifunc.GetStringUTFChars, Ptr{UInt8},
+                            (Ptr{JNIEnv}, Ptr{Nothing}, Ptr{jboolean}), penv, jstr.ptr, pIsCopy)
+    s = unsafe_string(buf)
+    ccall(jnifunc.ReleaseStringUTFChars, Nothing, (Ptr{JNIEnv}, Ptr{Nothing}, Ptr{UInt8}), penv,
+          jstr.ptr, buf)
     return s
 end
 
-for (x, y, z) in [ (:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.ReleaseBooleanArrayElements)),
+for (x, y, z) in [(:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.ReleaseBooleanArrayElements)),
                   (:jchar, :(jnifunc.GetCharArrayElements), :(jnifunc.ReleaseCharArrayElements)),
                   (:jbyte, :(jnifunc.GetByteArrayElements), :(jnifunc.ReleaseByteArrayElements)),
                   (:jshort, :(jnifunc.GetShortArrayElements), :(jnifunc.ReleaseShortArrayElements)),
@@ -256,13 +283,14 @@ for (x, y, z) in [ (:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.Rel
                   (:jlong, :(jnifunc.GetLongArrayElements), :(jnifunc.ReleaseLongArrayElements)),
                   (:jfloat, :(jnifunc.GetFloatArrayElements), :(jnifunc.ReleaseFloatArrayElements)),
                   (:jdouble, :(jnifunc.GetDoubleArrayElements), :(jnifunc.ReleaseDoubleArrayElements)) ]
-    m=quote
+    m = quote
         function convert(::Type{Array{$(x),1}}, obj::JObject)
-            sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Void}), penv, obj.ptr)
-            arr = ccall($(y), Ptr{$(x)}, (Ptr{JNIEnv}, Ptr{Void}, Ptr{jboolean} ), penv, obj.ptr, C_NULL )
-            jl_arr::Array = unsafe_wrap(Array, arr, Int(sz), false)
+            sz = ccall(jnifunc.GetArrayLength, jint, (Ptr{JNIEnv}, Ptr{Nothing}), penv, obj.ptr)
+            arr = ccall($(y), Ptr{$(x)}, (Ptr{JNIEnv}, Ptr{Nothing}, Ptr{jboolean}), penv, obj.ptr,
+                        C_NULL)
+            jl_arr::Array = unsafe_wrap(Array, arr, Int(sz))
             jl_arr = deepcopy(jl_arr)
-            ccall($(z), Void, (Ptr{JNIEnv},Ptr{Void}, Ptr{$(x)}, jint), penv, obj.ptr, arr, 0)
+            ccall($(z), Nothing, (Ptr{JNIEnv},Ptr{Nothing}, Ptr{$(x)}, jint), penv, obj.ptr, arr, 0)
             return jl_arr
         end
     end
@@ -270,13 +298,13 @@ for (x, y, z) in [ (:jboolean, :(jnifunc.GetBooleanArrayElements), :(jnifunc.Rel
 end
 
 
-function convert{T}(::Type{Array{T, 1}}, obj::JObject)
+function convert(::Type{Array{T, 1}}, obj::JObject) where T
     sz = ccall(jnifunc.GetArrayLength, jint,
-               (Ptr{JNIEnv}, Ptr{Void}), penv, obj.ptr)
-    ret = Array{T}(sz)
+               (Ptr{JNIEnv}, Ptr{Nothing}), penv, obj.ptr)
+    ret = Array{T}(undef, sz)
     for i=1:sz
-        ptr = ccall(jnifunc.GetObjectArrayElement, Ptr{Void},
-                  (Ptr{JNIEnv}, Ptr{Void}, jint), penv, obj.ptr, i-1)
+        ptr = ccall(jnifunc.GetObjectArrayElement, Ptr{Nothing},
+                  (Ptr{JNIEnv}, Ptr{Nothing}, jint), penv, obj.ptr, i-1)
         ret[i] = convert(T, JObject(ptr))
     end
     return ret
@@ -296,6 +324,7 @@ function narrow(obj::JavaObject)
     return convert(JavaObject{Symbol(t)}, obj)
 end
 
+# TODO replace once iterate is available in Compat
 Base.start(itr::JavaObject) = true
 function Base.next(itr::JavaObject, state)
      o = jcall(itr, "next", @jimport(java.lang.Object), ())

--- a/src/jnienv.jl
+++ b/src/jnienv.jl
@@ -1,331 +1,331 @@
 
 
-immutable JNINativeInterface #struct JNINativeInterface_ {
-    
-    reserved0::Ptr{Void} # void *reserved0;
-    
-    reserved1::Ptr{Void} #void *reserved1;
-    reserved2::Ptr{Void} #void *reserved2;
-    reserved3::Ptr{Void} #void *reserved3;
-
-    GetVersion::Ptr{Void} #jint ( *GetVersion)(JNIEnv *env);
-    DefineClass::Ptr{Void} #jclass ( *DefineClass) (JNIEnv *env, const char *name, jobject loader, const jbyte *buf, jsize len);
-    FindClass::Ptr{Void} #jclass ( *FindClass) (JNIEnv *env, const char *name);
-    FromReflectedMethod::Ptr{Void} #jmethodID ( *FromReflectedMethod) (JNIEnv *env, jobject method);
-    FromReflectedField::Ptr{Void} #jfieldID ( *FromReflectedField)(JNIEnv *env, jobject field);
-    ToReflectedMethod::Ptr{Void} #jobject ( *ToReflectedMethod) (JNIEnv *env, jclass cls, jmethodID methodID, jboolean isStatic);
-
-    GetSuperClass::Ptr{Void}  #jclass ( *GetSuperclass) (JNIEnv *env, jclass sub);
-    IsAssignableFrom::Ptr{Void} #jboolean ( *IsAssignableFrom) (JNIEnv *env, jclass sub, jclass sup);
-
-    ToReflectedField::Ptr{Void} #jobject ( *ToReflectedField)(JNIEnv *env, jclass cls, jfieldID fieldID, jboolean isStatic);
-
-    Throw::Ptr{Void} #jint ( *Throw) (JNIEnv *env, jthrowable obj);
-    ThrowNew::Ptr{Void} #jint ( *ThrowNew)(JNIEnv *env, jclass clazz, const char *msg);
-    ExceptionOccurred::Ptr{Void} #jthrowable ( *ExceptionOccurred) (JNIEnv *env);
-    ExceptionDescribe::Ptr{Void} #void ( *ExceptionDescribe)(JNIEnv *env);
-    ExceptionClear::Ptr{Void} #void ( *ExceptionClear) (JNIEnv *env);
-    FatalError::Ptr{Void} #void ( *FatalError) (JNIEnv *env, const char *msg);
-
-    PushLocalFrame::Ptr{Void} #jint ( *PushLocalFrame) (JNIEnv *env, jint capacity);
-    PopLocalFrame::Ptr{Void} #jobject ( *PopLocalFrame) (JNIEnv *env, jobject result);
-
-    NewGlobalRef::Ptr{Void} #jobject ( *NewGlobalRef) (JNIEnv *env, jobject lobj);
-    DeleteGlobalRef::Ptr{Void} #void ( *DeleteGlobalRef) (JNIEnv *env, jobject gref);
-    DeleteLocalRef::Ptr{Void} #void ( *DeleteLocalRef) (JNIEnv *env, jobject obj);
-    IsSameObject::Ptr{Void} #jboolean ( *IsSameObject) (JNIEnv *env, jobject obj1, jobject obj2);
-    NewLocalRef::Ptr{Void} #jobject ( *NewLocalRef) (JNIEnv *env, jobject ref);
-    EnsureLocalCapacity::Ptr{Void} #jint ( *EnsureLocalCapacity) (JNIEnv *env, jint capacity);
-
-    AllocObject::Ptr{Void} #jobject ( *AllocObject) (JNIEnv *env, jclass clazz);
-    NewObject::Ptr{Void} #jobject ( *NewObject) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    NewObjectV::Ptr{Void} #jobject ( *NewObjectV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    NewObjectA::Ptr{Void} #jobject ( *NewObjectA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    GetObjectClass::Ptr{Void} #jclass ( *GetObjectClass) (JNIEnv *env, jobject obj);
-    IsInstanceOf::Ptr{Void} #jboolean ( *IsInstanceOf) (JNIEnv *env, jobject obj, jclass clazz);
-
-    GetMethodID::Ptr{Void} #jmethodID ( *GetMethodID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
-
-    CallObjectMethod::Ptr{Void} #jobject ( *CallObjectMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallObjectMethodV::Ptr{Void} #jobject ( *CallObjectMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallObjectMethodA::Ptr{Void} #jobject ( *CallObjectMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue * args);
-
-    CallBooleanMethod::Ptr{Void} #jboolean ( *CallBooleanMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallBooleanMethodV::Ptr{Void} #jboolean ( *CallBooleanMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallBooleanMethodA::Ptr{Void} #jboolean ( *CallBooleanMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue * args);
-
-    CallByteMethod::Ptr{Void} #jbyte ( *CallByteMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallByteMethodV::Ptr{Void} #jbyte ( *CallByteMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallByteMethodA::Ptr{Void} #jbyte ( *CallByteMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
-
-    CallCharMethod::Ptr{Void} #jchar ( *CallCharMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallCharMethodV::Ptr{Void} #jchar ( *CallCharMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallCharMethodA::Ptr{Void} #jchar ( *CallCharMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
-
-    CallShortMethod::Ptr{Void} #jshort ( *CallShortMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallShortMethodV::Ptr{Void} #jshort ( *CallShortMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallShortMethodA::Ptr{Void} #jshort ( *CallShortMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
-
-    CallIntMethod::Ptr{Void} #jint ( *CallIntMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallIntMethodV::Ptr{Void} #jint ( *CallIntMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallIntMethodA::Ptr{Void} #jint ( *CallIntMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
-
-    CallLongMethod::Ptr{Void} #jlong ( *CallLongMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallLongMethodV::Ptr{Void} #jlong ( *CallLongMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallLongMethodA::Ptr{Void} #jlong ( *CallLongMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
-
-    CallFloatMethod::Ptr{Void} #jfloat ( *CallFloatMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallFloatMEthodV::Ptr{Void} #jfloat ( *CallFloatMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallFloatMethodA::Ptr{Void} #jfloat ( *CallFloatMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
-
-    CallDoubleMethod::Ptr{Void} #jdouble ( *CallDoubleMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallDoubleMethodV::Ptr{Void} #jdouble ( *CallDoubleMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallDoubleMethodA::Ptr{Void} #jdouble ( *CallDoubleMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
-
-    CallVoidMethod::Ptr{Void} #void ( *CallVoidMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
-    CallVoidMethodV::Ptr{Void} #void ( *CallVoidMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
-    CallVoidMethodA::Ptr{Void} #void ( *CallVoidMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue * args);
-
-    CallNonvirtualObjectMethod::Ptr{Void} #jobject ( *CallNonvirtualObjectMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualObjectMethodV::Ptr{Void} #jobject ( *CallNonvirtualObjectMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualObjectMEthodA::Ptr{Void} #jobject ( *CallNonvirtualObjectMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue * args);
-
-    CallNonvirtualBooleanMethod::Ptr{Void} #jboolean ( *CallNonvirtualBooleanMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualBooleanMethodV::Ptr{Void} #jboolean ( *CallNonvirtualBooleanMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualBooleanMethodA::Ptr{Void} #jboolean ( *CallNonvirtualBooleanMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue * args);
-
-    CallNonvirtualByteMethod::Ptr{Void} #jbyte ( *CallNonvirtualByteMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualByteMethodV::Ptr{Void} #jbyte ( *CallNonvirtualByteMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualByteMethodA::Ptr{Void} #jbyte ( *CallNonvirtualByteMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallNonvirtualCharMethod::Ptr{Void} #jchar ( *CallNonvirtualCharMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualCharMethodV::Ptr{Void} #jchar ( *CallNonvirtualCharMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualCharMethodA::Ptr{Void} #jchar ( *CallNonvirtualCharMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallNonvirtualShortMethod::Ptr{Void} #jshort ( *CallNonvirtualShortMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualShortMethodV::Ptr{Void} #jshort ( *CallNonvirtualShortMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualShortMethodA::Ptr{Void} #jshort ( *CallNonvirtualShortMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallNonvirtualIntMethod::Ptr{Void} #jint ( *CallNonvirtualIntMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualIntMethodV::Ptr{Void} #jint ( *CallNonvirtualIntMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualIntMethodA::Ptr{Void} #jint ( *CallNonvirtualIntMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallNonvirtualLongMethod::Ptr{Void} #jlong ( *CallNonvirtualLongMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonVirtualLongMethodV::Ptr{Void} #jlong ( *CallNonvirtualLongMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualLongMethodA::Ptr{Void} #jlong ( *CallNonvirtualLongMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallNonVirtualFloatMethod::Ptr{Void} #jfloat ( *CallNonvirtualFloatMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualFloatMethodV::Ptr{Void} #jfloat ( *CallNonvirtualFloatMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualFloatMethodA::Ptr{Void} #jfloat ( *CallNonvirtualFloatMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallNonvirtualDoubleMethod::Ptr{Void} # jdouble ( *CallNonvirtualDoubleMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualDoubleMethodV::Ptr{Void} # jdouble ( *CallNonvirtualDoubleMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualDoubleMethodA::Ptr{Void} # jdouble ( *CallNonvirtualDoubleMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID,  const jvalue *args);
-
-    CallNonvirtualVoidMethod::Ptr{Void} # void ( *CallNonvirtualVoidMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
-    CallNonvirtualVoidMethodV::Ptr{Void} # void ( *CallNonvirtualVoidMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
-    CallNonvirtualVoidMethodA::Ptr{Void} # void ( *CallNonvirtualVoidMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue * args);
-
-    GetFieldID::Ptr{Void} # jfieldID ( *GetFieldID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
-
-    GetObjectField::Ptr{Void} # jobject ( *GetObjectField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetBooleanField::Ptr{Void} # jboolean ( *GetBooleanField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetByteField::Ptr{Void} # jbyte ( *GetByteField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetCharField::Ptr{Void} # jchar ( *GetCharField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetShortField::Ptr{Void} # jshort ( *GetShortField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetIntField::Ptr{Void} # jint ( *GetIntField)  (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetLongField::Ptr{Void} # jlong ( *GetLongField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetFloatField::Ptr{Void} # jfloat ( *GetFloatField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-    GetDoubleField::Ptr{Void} # jdouble ( *GetDoubleField) (JNIEnv *env, jobject obj, jfieldID fieldID);
-
-    SetObjectField::Ptr{Void} # void ( *SetObjectField) (JNIEnv *env, jobject obj, jfieldID fieldID, jobject val);
-    SetBooleanField::Ptr{Void} # void ( *SetBooleanField) (JNIEnv *env, jobject obj, jfieldID fieldID, jboolean val);
-    SetByteField::Ptr{Void} # void ( *SetByteField)  (JNIEnv *env, jobject obj, jfieldID fieldID, jbyte val);
-    SetCharField::Ptr{Void} # void ( *SetCharField) (JNIEnv *env, jobject obj, jfieldID fieldID, jchar val);
-    SetShortField::Ptr{Void} # void ( *SetShortField) (JNIEnv *env, jobject obj, jfieldID fieldID, jshort val);
-    SetIntField::Ptr{Void} # void ( *SetIntField) (JNIEnv *env, jobject obj, jfieldID fieldID, jint val);
-    SetLongField::Ptr{Void} # void ( *SetLongField) (JNIEnv *env, jobject obj, jfieldID fieldID, jlong val);
-    SetFloatField::Ptr{Void} # void ( *SetFloatField) (JNIEnv *env, jobject obj, jfieldID fieldID, jfloat val);
-    SetDoubleField::Ptr{Void} # void ( *SetDoubleField) (JNIEnv *env, jobject obj, jfieldID fieldID, jdouble val);
-
-    GetStaticMethodID::Ptr{Void} # jmethodID ( *GetStaticMethodID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
-
-    CallStaticObjectMethod::Ptr{Void} # jobject ( *CallStaticObjectMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticObjectMethodV::Ptr{Void} #jobject ( *CallStaticObjectMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticObjectMethodA::Ptr{Void} # jobject ( *CallStaticObjectMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticBooleanMethod::Ptr{Void} # jboolean ( *CallStaticBooleanMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticBooleanMethodV::Ptr{Void} # jboolean ( *CallStaticBooleanMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticBooleanMethodA::Ptr{Void} # jboolean ( *CallStaticBooleanMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticByteMethod::Ptr{Void} #jbyte ( *CallStaticByteMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticByteMethodV::Ptr{Void} # jbyte ( *CallStaticByteMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticByteMethodA::Ptr{Void} #jbyte ( *CallStaticByteMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticCharMethod::Ptr{Void} # jchar ( *CallStaticCharMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticCharMethodV::Ptr{Void} # jchar ( *CallStaticCharMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticCharMethodA::Ptr{Void} # jchar ( *CallStaticCharMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticShortMethod::Ptr{Void} # jshort ( *CallStaticShortMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticShortMethodV::Ptr{Void} # jshort ( *CallStaticShortMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticShortMethodA::Ptr{Void} # jshort ( *CallStaticShortMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticIntMethod::Ptr{Void} #jint ( *CallStaticIntMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticIntMethodV::Ptr{Void} # jint ( *CallStaticIntMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticIntMethodA::Ptr{Void} # jint ( *CallStaticIntMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticLongMethod::Ptr{Void} # jlong ( *CallStaticLongMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticLongMethodV::Ptr{Void} # jlong ( *CallStaticLongMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticLongMethodA::Ptr{Void} # jlong ( *CallStaticLongMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticFloatMethod::Ptr{Void} # jfloat ( *CallStaticFloatMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticFloatMethodV::Ptr{Void} # jfloat ( *CallStaticFloatMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticFloatMethodA::Ptr{Void} # jfloat ( *CallStaticFloatMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticDoubleMethod::Ptr{Void} # jdouble ( *CallStaticDoubleMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
-    CallStaticDoubleMethodV::Ptr{Void} # jdouble ( *CallStaticDoubleMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
-    CallStaticDoubleMethodA::Ptr{Void} # jdouble ( *CallStaticDoubleMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
-
-    CallStaticVoidMethod::Ptr{Void} # void ( *CallStaticVoidMethod) (JNIEnv *env, jclass cls, jmethodID methodID, ...);
-    CallStaticVoidMethodV::Ptr{Void} # void ( *CallStaticVoidMethodV) (JNIEnv *env, jclass cls, jmethodID methodID, va_list args);
-    CallStaticVoidMethodA::Ptr{Void} # void ( *CallStaticVoidMethodA) (JNIEnv *env, jclass cls, jmethodID methodID, const jvalue * args);
-
-    GetStaticFieldID::Ptr{Void} # jfieldID ( *GetStaticFieldID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
-    GetStaticObjectField::Ptr{Void} # jobject ( *GetStaticObjectField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticBooleanField::Ptr{Void} # jboolean ( *GetStaticBooleanField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticByteField::Ptr{Void} # jbyte ( *GetStaticByteField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticCharField::Ptr{Void} # jchar ( *GetStaticCharField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticShortField::Ptr{Void} # jshort ( *GetStaticShortField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticIntField::Ptr{Void} # jint ( *GetStaticIntField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticLongField::Ptr{Void} # jlong ( *GetStaticLongField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticFloatField::Ptr{Void} # jfloat ( *GetStaticFloatField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-    GetStaticDoubleField::Ptr{Void} # jdouble ( *GetStaticDoubleField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
-
-    SetStaticObjectField::Ptr{Void} # void ( *SetStaticObjectField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jobject value);
-    SetStaticBooleanField::Ptr{Void} # void ( *SetStaticBooleanField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jboolean value);
-    SetStaticByteField::Ptr{Void} # void ( *SetStaticByteField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jbyte value);
-    SetStaticCharField::Ptr{Void} # void ( *SetStaticCharField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jchar value);
-    SetStaticShortField::Ptr{Void} # void ( *SetStaticShortField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jshort value);
-    SetStaticIntField::Ptr{Void} # void ( *SetStaticIntField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jint value);
-    SetStaticLongField::Ptr{Void} # void ( *SetStaticLongField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jlong value);
-    SetStaticFloatField::Ptr{Void} # void ( *SetStaticFloatField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jfloat value);
-    SetStaticDoubleField::Ptr{Void} # void ( *SetStaticDoubleField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jdouble value);
-
-    NewString::Ptr{Void} #::Ptr{Void} # jstring ( *NewString) (JNIEnv *env, const jchar *unicode, jsize len);
-    GetStringLength::Ptr{Void} # jsize ( *GetStringLength) (JNIEnv *env, jstring str);
-    GetStringChars::Ptr{Void} # const jchar *( *GetStringChars) (JNIEnv *env, jstring str, jboolean *isCopy);
-    ReleaseStringChars::Ptr{Void} # void ( *ReleaseStringChars) (JNIEnv *env, jstring str, const jchar *chars);
-
-    NewStringUTF::Ptr{Void} # jstring ( *NewStringUTF) (JNIEnv *env, const char *utf);
-    GetStringUTFLength::Ptr{Void} # jsize ( *GetStringUTFLength) (JNIEnv *env, jstring str);
-    GetStringUTFChars::Ptr{Void} # const char* ( *GetStringUTFChars) (JNIEnv *env, jstring str, jboolean *isCopy);
-    ReleaseStringUTFChars::Ptr{Void} # void ( *ReleaseStringUTFChars) (JNIEnv *env, jstring str, const char* chars);
-
-
-    GetArrayLength::Ptr{Void} # jsize ( *GetArrayLength ) (JNIEnv *env, jarray array);
-
-    NewObjectArray::Ptr{Void} # jobjectArray ( *NewObjectArray) (JNIEnv *env, jsize len, jclass clazz, jobject init);
-    GetObjectArrayElement::Ptr{Void} # jobject ( *GetObjectArrayElement) (JNIEnv *env, jobjectArray array, jsize index);
-    SetObjectArrayElement::Ptr{Void} # void ( *SetObjectArrayElement) (JNIEnv *env, jobjectArray array, jsize index, jobject val);
-
-    NewBooleanArray::Ptr{Void} # jbooleanArray ( *NewBooleanArray) (JNIEnv *env, jsize len);
-    NewByteArray::Ptr{Void} # jbyteArray ( *NewByteArray) (JNIEnv *env, jsize len);
-    NewCharArray::Ptr{Void} # jcharArray ( *NewCharArray) (JNIEnv *env, jsize len);
-    NewShortArray::Ptr{Void} # jshortArray ( *NewShortArray) (JNIEnv *env, jsize len);
-    NewIntArray::Ptr{Void} # jintArray ( *NewIntArray) (JNIEnv *env, jsize len);
-    NewLongArray::Ptr{Void} # jlongArray ( *NewLongArray) (JNIEnv *env, jsize len);
-    NewFloatArray::Ptr{Void} # jfloatArray ( *NewFloatArray) (JNIEnv *env, jsize len);
-    NewDoubleArray::Ptr{Void} # jdoubleArray ( *NewDoubleArray) (JNIEnv *env, jsize len);
-
-    GetBooleanArrayElements::Ptr{Void} # jboolean * ( *GetBooleanArrayElements) (JNIEnv *env, jbooleanArray array, jboolean *isCopy);
-    GetByteArrayElements::Ptr{Void} # jbyte * ( *GetByteArrayElements) (JNIEnv *env, jbyteArray array, jboolean *isCopy);
-    GetCharArrayElements::Ptr{Void} # jchar * ( *GetCharArrayElements) (JNIEnv *env, jcharArray array, jboolean *isCopy);
-    GetShortArrayElements::Ptr{Void} # jshort * ( *GetShortArrayElements) (JNIEnv *env, jshortArray array, jboolean *isCopy);
-    GetIntArrayElements::Ptr{Void} # jint * ( *GetIntArrayElements) (JNIEnv *env, jintArray array, jboolean *isCopy);
-    GetLongArrayElements::Ptr{Void} # jlong * ( *GetLongArrayElements ) (JNIEnv *env, jlongArray array, jboolean *isCopy);
-    GetFloatArrayElements::Ptr{Void} # jfloat * ( *GetFloatArrayElements) (JNIEnv *env, jfloatArray array, jboolean *isCopy);
-    GetDoubleArrayElements::Ptr{Void} # jdouble * ( *GetDoubleArrayElements) (JNIEnv *env, jdoubleArray array, jboolean *isCopy);
-
-    ReleaseBooleanArrayElements::Ptr{Void} # void ( *ReleaseBooleanArrayElements ) (JNIEnv *env, jbooleanArray array, jboolean *elems, jint mode);
-    ReleaseByteArrayElements::Ptr{Void} # void ( *ReleaseByteArrayElements ) (JNIEnv *env, jbyteArray array, jbyte *elems, jint mode);
-    ReleaseCharArrayElements::Ptr{Void} # void ( *ReleaseCharArrayElements ) (JNIEnv *env, jcharArray array, jchar *elems, jint mode);
-    ReleaseShortArrayElements::Ptr{Void} # void ( *ReleaseShortArrayElements) (JNIEnv *env, jshortArray array, jshort *elems, jint mode);
-    ReleaseIntArrayElements::Ptr{Void} # void ( *ReleaseIntArrayElements) (JNIEnv *env, jintArray array, jint *elems, jint mode);
-    ReleaseLongArrayElements::Ptr{Void} # void ( *ReleaseLongArrayElements ) (JNIEnv *env, jlongArray array, jlong *elems, jint mode);
-    ReleaseFloatArrayElements::Ptr{Void} # void ( *ReleaseFloatArrayElements) (JNIEnv *env, jfloatArray array, jfloat *elems, jint mode);
-    ReleaseDoubleArrayElements::Ptr{Void} # void ( *ReleaseDoubleArrayElements ) (JNIEnv *env, jdoubleArray array, jdouble *elems, jint mode);
-
-    GetBooleanArrayRegion::Ptr{Void} # void ( *GetBooleanArrayRegion ) (JNIEnv *env, jbooleanArray array, jsize start, jsize l, jboolean *buf);
-    GetByteArrayRegion::Ptr{Void} # void ( *GetByteArrayRegion) (JNIEnv *env, jbyteArray array, jsize start, jsize len, jbyte *buf);
-    vGetCharArrayRegion::Ptr{Void} # void ( *GetCharArrayRegion) (JNIEnv *env, jcharArray array, jsize start, jsize len, jchar *buf);
-    GetShortArrayRegion::Ptr{Void} # void ( *GetShortArrayRegion ) (JNIEnv *env, jshortArray array, jsize start, jsize len, jshort *buf);
-    GetIntArrayRegion::Ptr{Void} # void ( *GetIntArrayRegion ) (JNIEnv *env, jintArray array, jsize start, jsize len, jint *buf);
-    GetLongArrayRegion::Ptr{Void} # void ( *GetLongArrayRegion) (JNIEnv *env, jlongArray array, jsize start, jsize len, jlong *buf);
-    GetFloatArrayRegion::Ptr{Void} # void ( *GetFloatArrayRegion) (JNIEnv *env, jfloatArray array, jsize start, jsize len, jfloat *buf);
-    GetDoubleArrayRegion::Ptr{Void} # void ( *GetDoubleArrayRegion) (JNIEnv *env, jdoubleArray array, jsize start, jsize len, jdouble *buf);
-
-    SetBooleanArrayRegion::Ptr{Void} # void ( *SetBooleanArrayRegion )(JNIEnv *env, jbooleanArray array, jsize start, jsize l, const jboolean *buf);
-    SetByteArrayRegion::Ptr{Void} # void ( *SetByteArrayRegion) (JNIEnv *env, jbyteArray array, jsize start, jsize len, const jbyte *buf);
-    SetCharArrayRegion::Ptr{Void} # void ( *SetCharArrayRegion) (JNIEnv *env, jcharArray array, jsize start, jsize len, const jchar *buf);
-    SetShortArrayRegion::Ptr{Void} # void ( *SetShortArrayRegion ) (JNIEnv *env, jshortArray array, jsize start, jsize len, const jshort *buf);
-    SetIntArrayRegion::Ptr{Void} # void ( *SetIntArrayRegion) (JNIEnv *env, jintArray array, jsize start, jsize len, const jint *buf);
-    SetLongArrayRegion::Ptr{Void} # void ( *SetLongArrayRegion) (JNIEnv *env, jlongArray array, jsize start, jsize len, const jlong *buf);
-    SetFloatArrayRegion::Ptr{Void} # void ( *SetFloatArrayRegion ) (JNIEnv *env, jfloatArray array, jsize start, jsize len, const jfloat *buf);
-    SetDoubleArrayRegion::Ptr{Void} # void ( *SetDoubleArrayRegion) (JNIEnv *env, jdoubleArray array, jsize start, jsize len, const jdouble *buf);
-
-    RegisterNatives::Ptr{Void} # jint ( *RegisterNatives) (JNIEnv *env, jclass clazz, const JNINativeMethod *methods, jint nMethods);
-    UnregisterNatives::Ptr{Void} # jint ( *UnregisterNatives ) (JNIEnv *env, jclass clazz);
-
-    MonitorEnter::Ptr{Void} # jint ( *MonitorEnter) (JNIEnv *env, jobject obj);
-    MonitorExit::Ptr{Void} # jint ( *MonitorExit ) (JNIEnv *env, jobject obj);
-
-    GetJavaVM::Ptr{Void} # jint ( *GetJavaVM) (JNIEnv *env, JavaVM **vm);
-
-    GetStringRegion::Ptr{Void} # void ( *GetStringRegion ) (JNIEnv *env, jstring str, jsize start, jsize len, jchar *buf);
-    GetStringUTFRegion::Ptr{Void} # void ( *GetStringUTFRegion) (JNIEnv *env, jstring str, jsize start, jsize len, char *buf);
-
-    GetPrimitiveArrayCritical::Ptr{Void} # void * ( *GetPrimitiveArrayCritical) (JNIEnv *env, jarray array, jboolean *isCopy);
-    ReleasePrimitiveArrayCritical::Ptr{Void} # void ( *ReleasePrimitiveArrayCritical ) (JNIEnv *env, jarray array, void *carray, jint mode);
-
-    GetStringCritical::Ptr{Void} # const jchar * ( *GetStringCritical ) (JNIEnv *env, jstring string, jboolean *isCopy);
-    ReleaseStringCritical::Ptr{Void} # void ( *ReleaseStringCritical ) (JNIEnv *env, jstring string, const jchar *cstring);
-
-    NewWeakGlobalRef::Ptr{Void} # jweak ( *NewWeakGlobalRef) (JNIEnv *env, jobject obj);
-    DeleteWeakGlobalRef::Ptr{Void} # void ( *DeleteWeakGlobalRef) (JNIEnv *env, jweak ref);
-
-    ExceptionCheck::Ptr{Void} # jboolean ( *ExceptionCheck) (JNIEnv *env);
-
-    NewDirectByteBuffer::Ptr{Void} # jobject ( *NewDirectByteBuffer ) (JNIEnv* env, void* address, jlong capacity);
-    GetDirectBufferAddress::Ptr{Void} # void* ( *GetDirectBufferAddress ) (JNIEnv* env, jobject buf);
-    GetDirectBufferCapacity::Ptr{Void} # jlong ( *GetDirectBufferCapacity) (JNIEnv* env, jobject buf);
+struct JNINativeInterface #struct JNINativeInterface_ {
+
+    reserved0::Ptr{Nothing} # void *reserved0;
+
+    reserved1::Ptr{Nothing} #void *reserved1;
+    reserved2::Ptr{Nothing} #void *reserved2;
+    reserved3::Ptr{Nothing} #void *reserved3;
+
+    GetVersion::Ptr{Nothing} #jint ( *GetVersion)(JNIEnv *env);
+    DefineClass::Ptr{Nothing} #jclass ( *DefineClass) (JNIEnv *env, const char *name, jobject loader, const jbyte *buf, jsize len);
+    FindClass::Ptr{Nothing} #jclass ( *FindClass) (JNIEnv *env, const char *name);
+    FromReflectedMethod::Ptr{Nothing} #jmethodID ( *FromReflectedMethod) (JNIEnv *env, jobject method);
+    FromReflectedField::Ptr{Nothing} #jfieldID ( *FromReflectedField)(JNIEnv *env, jobject field);
+    ToReflectedMethod::Ptr{Nothing} #jobject ( *ToReflectedMethod) (JNIEnv *env, jclass cls, jmethodID methodID, jboolean isStatic);
+
+    GetSuperClass::Ptr{Nothing}  #jclass ( *GetSuperclass) (JNIEnv *env, jclass sub);
+    IsAssignableFrom::Ptr{Nothing} #jboolean ( *IsAssignableFrom) (JNIEnv *env, jclass sub, jclass sup);
+
+    ToReflectedField::Ptr{Nothing} #jobject ( *ToReflectedField)(JNIEnv *env, jclass cls, jfieldID fieldID, jboolean isStatic);
+
+    Throw::Ptr{Nothing} #jint ( *Throw) (JNIEnv *env, jthrowable obj);
+    ThrowNew::Ptr{Nothing} #jint ( *ThrowNew)(JNIEnv *env, jclass clazz, const char *msg);
+    ExceptionOccurred::Ptr{Nothing} #jthrowable ( *ExceptionOccurred) (JNIEnv *env);
+    ExceptionDescribe::Ptr{Nothing} #void ( *ExceptionDescribe)(JNIEnv *env);
+    ExceptionClear::Ptr{Nothing} #void ( *ExceptionClear) (JNIEnv *env);
+    FatalError::Ptr{Nothing} #void ( *FatalError) (JNIEnv *env, const char *msg);
+
+    PushLocalFrame::Ptr{Nothing} #jint ( *PushLocalFrame) (JNIEnv *env, jint capacity);
+    PopLocalFrame::Ptr{Nothing} #jobject ( *PopLocalFrame) (JNIEnv *env, jobject result);
+
+    NewGlobalRef::Ptr{Nothing} #jobject ( *NewGlobalRef) (JNIEnv *env, jobject lobj);
+    DeleteGlobalRef::Ptr{Nothing} #void ( *DeleteGlobalRef) (JNIEnv *env, jobject gref);
+    DeleteLocalRef::Ptr{Nothing} #void ( *DeleteLocalRef) (JNIEnv *env, jobject obj);
+    IsSameObject::Ptr{Nothing} #jboolean ( *IsSameObject) (JNIEnv *env, jobject obj1, jobject obj2);
+    NewLocalRef::Ptr{Nothing} #jobject ( *NewLocalRef) (JNIEnv *env, jobject ref);
+    EnsureLocalCapacity::Ptr{Nothing} #jint ( *EnsureLocalCapacity) (JNIEnv *env, jint capacity);
+
+    AllocObject::Ptr{Nothing} #jobject ( *AllocObject) (JNIEnv *env, jclass clazz);
+    NewObject::Ptr{Nothing} #jobject ( *NewObject) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    NewObjectV::Ptr{Nothing} #jobject ( *NewObjectV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    NewObjectA::Ptr{Nothing} #jobject ( *NewObjectA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    GetObjectClass::Ptr{Nothing} #jclass ( *GetObjectClass) (JNIEnv *env, jobject obj);
+    IsInstanceOf::Ptr{Nothing} #jboolean ( *IsInstanceOf) (JNIEnv *env, jobject obj, jclass clazz);
+
+    GetMethodID::Ptr{Nothing} #jmethodID ( *GetMethodID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
+
+    CallObjectMethod::Ptr{Nothing} #jobject ( *CallObjectMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallObjectMethodV::Ptr{Nothing} #jobject ( *CallObjectMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallObjectMethodA::Ptr{Nothing} #jobject ( *CallObjectMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue * args);
+
+    CallBooleanMethod::Ptr{Nothing} #jboolean ( *CallBooleanMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallBooleanMethodV::Ptr{Nothing} #jboolean ( *CallBooleanMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallBooleanMethodA::Ptr{Nothing} #jboolean ( *CallBooleanMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue * args);
+
+    CallByteMethod::Ptr{Nothing} #jbyte ( *CallByteMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallByteMethodV::Ptr{Nothing} #jbyte ( *CallByteMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallByteMethodA::Ptr{Nothing} #jbyte ( *CallByteMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
+
+    CallCharMethod::Ptr{Nothing} #jchar ( *CallCharMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallCharMethodV::Ptr{Nothing} #jchar ( *CallCharMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallCharMethodA::Ptr{Nothing} #jchar ( *CallCharMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
+
+    CallShortMethod::Ptr{Nothing} #jshort ( *CallShortMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallShortMethodV::Ptr{Nothing} #jshort ( *CallShortMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallShortMethodA::Ptr{Nothing} #jshort ( *CallShortMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
+
+    CallIntMethod::Ptr{Nothing} #jint ( *CallIntMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallIntMethodV::Ptr{Nothing} #jint ( *CallIntMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallIntMethodA::Ptr{Nothing} #jint ( *CallIntMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
+
+    CallLongMethod::Ptr{Nothing} #jlong ( *CallLongMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallLongMethodV::Ptr{Nothing} #jlong ( *CallLongMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallLongMethodA::Ptr{Nothing} #jlong ( *CallLongMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
+
+    CallFloatMethod::Ptr{Nothing} #jfloat ( *CallFloatMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallFloatMEthodV::Ptr{Nothing} #jfloat ( *CallFloatMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallFloatMethodA::Ptr{Nothing} #jfloat ( *CallFloatMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
+
+    CallDoubleMethod::Ptr{Nothing} #jdouble ( *CallDoubleMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallDoubleMethodV::Ptr{Nothing} #jdouble ( *CallDoubleMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallDoubleMethodA::Ptr{Nothing} #jdouble ( *CallDoubleMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue *args);
+
+    CallNothingMethod::Ptr{Nothing} #void ( *CallNothingMethod) (JNIEnv *env, jobject obj, jmethodID methodID, ...);
+    CallNothingMethodV::Ptr{Nothing} #void ( *CallNothingMethodV) (JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+    CallNothingMethodA::Ptr{Nothing} #void ( *CallNothingMethodA) (JNIEnv *env, jobject obj, jmethodID methodID, const jvalue * args);
+
+    CallNonvirtualObjectMethod::Ptr{Nothing} #jobject ( *CallNonvirtualObjectMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualObjectMethodV::Ptr{Nothing} #jobject ( *CallNonvirtualObjectMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualObjectMEthodA::Ptr{Nothing} #jobject ( *CallNonvirtualObjectMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue * args);
+
+    CallNonvirtualBooleanMethod::Ptr{Nothing} #jboolean ( *CallNonvirtualBooleanMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualBooleanMethodV::Ptr{Nothing} #jboolean ( *CallNonvirtualBooleanMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualBooleanMethodA::Ptr{Nothing} #jboolean ( *CallNonvirtualBooleanMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue * args);
+
+    CallNonvirtualByteMethod::Ptr{Nothing} #jbyte ( *CallNonvirtualByteMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualByteMethodV::Ptr{Nothing} #jbyte ( *CallNonvirtualByteMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualByteMethodA::Ptr{Nothing} #jbyte ( *CallNonvirtualByteMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallNonvirtualCharMethod::Ptr{Nothing} #jchar ( *CallNonvirtualCharMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualCharMethodV::Ptr{Nothing} #jchar ( *CallNonvirtualCharMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualCharMethodA::Ptr{Nothing} #jchar ( *CallNonvirtualCharMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallNonvirtualShortMethod::Ptr{Nothing} #jshort ( *CallNonvirtualShortMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualShortMethodV::Ptr{Nothing} #jshort ( *CallNonvirtualShortMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualShortMethodA::Ptr{Nothing} #jshort ( *CallNonvirtualShortMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallNonvirtualIntMethod::Ptr{Nothing} #jint ( *CallNonvirtualIntMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualIntMethodV::Ptr{Nothing} #jint ( *CallNonvirtualIntMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualIntMethodA::Ptr{Nothing} #jint ( *CallNonvirtualIntMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallNonvirtualLongMethod::Ptr{Nothing} #jlong ( *CallNonvirtualLongMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonVirtualLongMethodV::Ptr{Nothing} #jlong ( *CallNonvirtualLongMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualLongMethodA::Ptr{Nothing} #jlong ( *CallNonvirtualLongMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallNonVirtualFloatMethod::Ptr{Nothing} #jfloat ( *CallNonvirtualFloatMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualFloatMethodV::Ptr{Nothing} #jfloat ( *CallNonvirtualFloatMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualFloatMethodA::Ptr{Nothing} #jfloat ( *CallNonvirtualFloatMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallNonvirtualDoubleMethod::Ptr{Nothing} # jdouble ( *CallNonvirtualDoubleMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualDoubleMethodV::Ptr{Nothing} # jdouble ( *CallNonvirtualDoubleMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualDoubleMethodA::Ptr{Nothing} # jdouble ( *CallNonvirtualDoubleMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID,  const jvalue *args);
+
+    CallNonvirtualNothingMethod::Ptr{Nothing} # void ( *CallNonvirtualNothingMethod) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+    CallNonvirtualNothingMethodV::Ptr{Nothing} # void ( *CallNonvirtualNothingMethodV) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+    CallNonvirtualNothingMethodA::Ptr{Nothing} # void ( *CallNonvirtualNothingMethodA) (JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, const jvalue * args);
+
+    GetFieldID::Ptr{Nothing} # jfieldID ( *GetFieldID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
+
+    GetObjectField::Ptr{Nothing} # jobject ( *GetObjectField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetBooleanField::Ptr{Nothing} # jboolean ( *GetBooleanField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetByteField::Ptr{Nothing} # jbyte ( *GetByteField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetCharField::Ptr{Nothing} # jchar ( *GetCharField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetShortField::Ptr{Nothing} # jshort ( *GetShortField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetIntField::Ptr{Nothing} # jint ( *GetIntField)  (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetLongField::Ptr{Nothing} # jlong ( *GetLongField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetFloatField::Ptr{Nothing} # jfloat ( *GetFloatField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+    GetDoubleField::Ptr{Nothing} # jdouble ( *GetDoubleField) (JNIEnv *env, jobject obj, jfieldID fieldID);
+
+    SetObjectField::Ptr{Nothing} # void ( *SetObjectField) (JNIEnv *env, jobject obj, jfieldID fieldID, jobject val);
+    SetBooleanField::Ptr{Nothing} # void ( *SetBooleanField) (JNIEnv *env, jobject obj, jfieldID fieldID, jboolean val);
+    SetByteField::Ptr{Nothing} # void ( *SetByteField)  (JNIEnv *env, jobject obj, jfieldID fieldID, jbyte val);
+    SetCharField::Ptr{Nothing} # void ( *SetCharField) (JNIEnv *env, jobject obj, jfieldID fieldID, jchar val);
+    SetShortField::Ptr{Nothing} # void ( *SetShortField) (JNIEnv *env, jobject obj, jfieldID fieldID, jshort val);
+    SetIntField::Ptr{Nothing} # void ( *SetIntField) (JNIEnv *env, jobject obj, jfieldID fieldID, jint val);
+    SetLongField::Ptr{Nothing} # void ( *SetLongField) (JNIEnv *env, jobject obj, jfieldID fieldID, jlong val);
+    SetFloatField::Ptr{Nothing} # void ( *SetFloatField) (JNIEnv *env, jobject obj, jfieldID fieldID, jfloat val);
+    SetDoubleField::Ptr{Nothing} # void ( *SetDoubleField) (JNIEnv *env, jobject obj, jfieldID fieldID, jdouble val);
+
+    GetStaticMethodID::Ptr{Nothing} # jmethodID ( *GetStaticMethodID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
+
+    CallStaticObjectMethod::Ptr{Nothing} # jobject ( *CallStaticObjectMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticObjectMethodV::Ptr{Nothing} #jobject ( *CallStaticObjectMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticObjectMethodA::Ptr{Nothing} # jobject ( *CallStaticObjectMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticBooleanMethod::Ptr{Nothing} # jboolean ( *CallStaticBooleanMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticBooleanMethodV::Ptr{Nothing} # jboolean ( *CallStaticBooleanMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticBooleanMethodA::Ptr{Nothing} # jboolean ( *CallStaticBooleanMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticByteMethod::Ptr{Nothing} #jbyte ( *CallStaticByteMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticByteMethodV::Ptr{Nothing} # jbyte ( *CallStaticByteMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticByteMethodA::Ptr{Nothing} #jbyte ( *CallStaticByteMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticCharMethod::Ptr{Nothing} # jchar ( *CallStaticCharMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticCharMethodV::Ptr{Nothing} # jchar ( *CallStaticCharMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticCharMethodA::Ptr{Nothing} # jchar ( *CallStaticCharMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticShortMethod::Ptr{Nothing} # jshort ( *CallStaticShortMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticShortMethodV::Ptr{Nothing} # jshort ( *CallStaticShortMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticShortMethodA::Ptr{Nothing} # jshort ( *CallStaticShortMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticIntMethod::Ptr{Nothing} #jint ( *CallStaticIntMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticIntMethodV::Ptr{Nothing} # jint ( *CallStaticIntMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticIntMethodA::Ptr{Nothing} # jint ( *CallStaticIntMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticLongMethod::Ptr{Nothing} # jlong ( *CallStaticLongMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticLongMethodV::Ptr{Nothing} # jlong ( *CallStaticLongMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticLongMethodA::Ptr{Nothing} # jlong ( *CallStaticLongMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticFloatMethod::Ptr{Nothing} # jfloat ( *CallStaticFloatMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticFloatMethodV::Ptr{Nothing} # jfloat ( *CallStaticFloatMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticFloatMethodA::Ptr{Nothing} # jfloat ( *CallStaticFloatMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticDoubleMethod::Ptr{Nothing} # jdouble ( *CallStaticDoubleMethod) (JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+    CallStaticDoubleMethodV::Ptr{Nothing} # jdouble ( *CallStaticDoubleMethodV) (JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+    CallStaticDoubleMethodA::Ptr{Nothing} # jdouble ( *CallStaticDoubleMethodA) (JNIEnv *env, jclass clazz, jmethodID methodID, const jvalue *args);
+
+    CallStaticNothingMethod::Ptr{Nothing} # void ( *CallStaticNothingMethod) (JNIEnv *env, jclass cls, jmethodID methodID, ...);
+    CallStaticNothingMethodV::Ptr{Nothing} # void ( *CallStaticNothingMethodV) (JNIEnv *env, jclass cls, jmethodID methodID, va_list args);
+    CallStaticNothingMethodA::Ptr{Nothing} # void ( *CallStaticNothingMethodA) (JNIEnv *env, jclass cls, jmethodID methodID, const jvalue * args);
+
+    GetStaticFieldID::Ptr{Nothing} # jfieldID ( *GetStaticFieldID) (JNIEnv *env, jclass clazz, const char *name, const char *sig);
+    GetStaticObjectField::Ptr{Nothing} # jobject ( *GetStaticObjectField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticBooleanField::Ptr{Nothing} # jboolean ( *GetStaticBooleanField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticByteField::Ptr{Nothing} # jbyte ( *GetStaticByteField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticCharField::Ptr{Nothing} # jchar ( *GetStaticCharField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticShortField::Ptr{Nothing} # jshort ( *GetStaticShortField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticIntField::Ptr{Nothing} # jint ( *GetStaticIntField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticLongField::Ptr{Nothing} # jlong ( *GetStaticLongField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticFloatField::Ptr{Nothing} # jfloat ( *GetStaticFloatField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+    GetStaticDoubleField::Ptr{Nothing} # jdouble ( *GetStaticDoubleField) (JNIEnv *env, jclass clazz, jfieldID fieldID);
+
+    SetStaticObjectField::Ptr{Nothing} # void ( *SetStaticObjectField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jobject value);
+    SetStaticBooleanField::Ptr{Nothing} # void ( *SetStaticBooleanField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jboolean value);
+    SetStaticByteField::Ptr{Nothing} # void ( *SetStaticByteField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jbyte value);
+    SetStaticCharField::Ptr{Nothing} # void ( *SetStaticCharField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jchar value);
+    SetStaticShortField::Ptr{Nothing} # void ( *SetStaticShortField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jshort value);
+    SetStaticIntField::Ptr{Nothing} # void ( *SetStaticIntField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jint value);
+    SetStaticLongField::Ptr{Nothing} # void ( *SetStaticLongField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jlong value);
+    SetStaticFloatField::Ptr{Nothing} # void ( *SetStaticFloatField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jfloat value);
+    SetStaticDoubleField::Ptr{Nothing} # void ( *SetStaticDoubleField) (JNIEnv *env, jclass clazz, jfieldID fieldID, jdouble value);
+
+    NewString::Ptr{Nothing} #::Ptr{Nothing} # jstring ( *NewString) (JNIEnv *env, const jchar *unicode, jsize len);
+    GetStringLength::Ptr{Nothing} # jsize ( *GetStringLength) (JNIEnv *env, jstring str);
+    GetStringChars::Ptr{Nothing} # const jchar *( *GetStringChars) (JNIEnv *env, jstring str, jboolean *isCopy);
+    ReleaseStringChars::Ptr{Nothing} # void ( *ReleaseStringChars) (JNIEnv *env, jstring str, const jchar *chars);
+
+    NewStringUTF::Ptr{Nothing} # jstring ( *NewStringUTF) (JNIEnv *env, const char *utf);
+    GetStringUTFLength::Ptr{Nothing} # jsize ( *GetStringUTFLength) (JNIEnv *env, jstring str);
+    GetStringUTFChars::Ptr{Nothing} # const char* ( *GetStringUTFChars) (JNIEnv *env, jstring str, jboolean *isCopy);
+    ReleaseStringUTFChars::Ptr{Nothing} # void ( *ReleaseStringUTFChars) (JNIEnv *env, jstring str, const char* chars);
+
+
+    GetArrayLength::Ptr{Nothing} # jsize ( *GetArrayLength ) (JNIEnv *env, jarray array);
+
+    NewObjectArray::Ptr{Nothing} # jobjectArray ( *NewObjectArray) (JNIEnv *env, jsize len, jclass clazz, jobject init);
+    GetObjectArrayElement::Ptr{Nothing} # jobject ( *GetObjectArrayElement) (JNIEnv *env, jobjectArray array, jsize index);
+    SetObjectArrayElement::Ptr{Nothing} # void ( *SetObjectArrayElement) (JNIEnv *env, jobjectArray array, jsize index, jobject val);
+
+    NewBooleanArray::Ptr{Nothing} # jbooleanArray ( *NewBooleanArray) (JNIEnv *env, jsize len);
+    NewByteArray::Ptr{Nothing} # jbyteArray ( *NewByteArray) (JNIEnv *env, jsize len);
+    NewCharArray::Ptr{Nothing} # jcharArray ( *NewCharArray) (JNIEnv *env, jsize len);
+    NewShortArray::Ptr{Nothing} # jshortArray ( *NewShortArray) (JNIEnv *env, jsize len);
+    NewIntArray::Ptr{Nothing} # jintArray ( *NewIntArray) (JNIEnv *env, jsize len);
+    NewLongArray::Ptr{Nothing} # jlongArray ( *NewLongArray) (JNIEnv *env, jsize len);
+    NewFloatArray::Ptr{Nothing} # jfloatArray ( *NewFloatArray) (JNIEnv *env, jsize len);
+    NewDoubleArray::Ptr{Nothing} # jdoubleArray ( *NewDoubleArray) (JNIEnv *env, jsize len);
+
+    GetBooleanArrayElements::Ptr{Nothing} # jboolean * ( *GetBooleanArrayElements) (JNIEnv *env, jbooleanArray array, jboolean *isCopy);
+    GetByteArrayElements::Ptr{Nothing} # jbyte * ( *GetByteArrayElements) (JNIEnv *env, jbyteArray array, jboolean *isCopy);
+    GetCharArrayElements::Ptr{Nothing} # jchar * ( *GetCharArrayElements) (JNIEnv *env, jcharArray array, jboolean *isCopy);
+    GetShortArrayElements::Ptr{Nothing} # jshort * ( *GetShortArrayElements) (JNIEnv *env, jshortArray array, jboolean *isCopy);
+    GetIntArrayElements::Ptr{Nothing} # jint * ( *GetIntArrayElements) (JNIEnv *env, jintArray array, jboolean *isCopy);
+    GetLongArrayElements::Ptr{Nothing} # jlong * ( *GetLongArrayElements ) (JNIEnv *env, jlongArray array, jboolean *isCopy);
+    GetFloatArrayElements::Ptr{Nothing} # jfloat * ( *GetFloatArrayElements) (JNIEnv *env, jfloatArray array, jboolean *isCopy);
+    GetDoubleArrayElements::Ptr{Nothing} # jdouble * ( *GetDoubleArrayElements) (JNIEnv *env, jdoubleArray array, jboolean *isCopy);
+
+    ReleaseBooleanArrayElements::Ptr{Nothing} # void ( *ReleaseBooleanArrayElements ) (JNIEnv *env, jbooleanArray array, jboolean *elems, jint mode);
+    ReleaseByteArrayElements::Ptr{Nothing} # void ( *ReleaseByteArrayElements ) (JNIEnv *env, jbyteArray array, jbyte *elems, jint mode);
+    ReleaseCharArrayElements::Ptr{Nothing} # void ( *ReleaseCharArrayElements ) (JNIEnv *env, jcharArray array, jchar *elems, jint mode);
+    ReleaseShortArrayElements::Ptr{Nothing} # void ( *ReleaseShortArrayElements) (JNIEnv *env, jshortArray array, jshort *elems, jint mode);
+    ReleaseIntArrayElements::Ptr{Nothing} # void ( *ReleaseIntArrayElements) (JNIEnv *env, jintArray array, jint *elems, jint mode);
+    ReleaseLongArrayElements::Ptr{Nothing} # void ( *ReleaseLongArrayElements ) (JNIEnv *env, jlongArray array, jlong *elems, jint mode);
+    ReleaseFloatArrayElements::Ptr{Nothing} # void ( *ReleaseFloatArrayElements) (JNIEnv *env, jfloatArray array, jfloat *elems, jint mode);
+    ReleaseDoubleArrayElements::Ptr{Nothing} # void ( *ReleaseDoubleArrayElements ) (JNIEnv *env, jdoubleArray array, jdouble *elems, jint mode);
+
+    GetBooleanArrayRegion::Ptr{Nothing} # void ( *GetBooleanArrayRegion ) (JNIEnv *env, jbooleanArray array, jsize start, jsize l, jboolean *buf);
+    GetByteArrayRegion::Ptr{Nothing} # void ( *GetByteArrayRegion) (JNIEnv *env, jbyteArray array, jsize start, jsize len, jbyte *buf);
+    vGetCharArrayRegion::Ptr{Nothing} # void ( *GetCharArrayRegion) (JNIEnv *env, jcharArray array, jsize start, jsize len, jchar *buf);
+    GetShortArrayRegion::Ptr{Nothing} # void ( *GetShortArrayRegion ) (JNIEnv *env, jshortArray array, jsize start, jsize len, jshort *buf);
+    GetIntArrayRegion::Ptr{Nothing} # void ( *GetIntArrayRegion ) (JNIEnv *env, jintArray array, jsize start, jsize len, jint *buf);
+    GetLongArrayRegion::Ptr{Nothing} # void ( *GetLongArrayRegion) (JNIEnv *env, jlongArray array, jsize start, jsize len, jlong *buf);
+    GetFloatArrayRegion::Ptr{Nothing} # void ( *GetFloatArrayRegion) (JNIEnv *env, jfloatArray array, jsize start, jsize len, jfloat *buf);
+    GetDoubleArrayRegion::Ptr{Nothing} # void ( *GetDoubleArrayRegion) (JNIEnv *env, jdoubleArray array, jsize start, jsize len, jdouble *buf);
+
+    SetBooleanArrayRegion::Ptr{Nothing} # void ( *SetBooleanArrayRegion )(JNIEnv *env, jbooleanArray array, jsize start, jsize l, const jboolean *buf);
+    SetByteArrayRegion::Ptr{Nothing} # void ( *SetByteArrayRegion) (JNIEnv *env, jbyteArray array, jsize start, jsize len, const jbyte *buf);
+    SetCharArrayRegion::Ptr{Nothing} # void ( *SetCharArrayRegion) (JNIEnv *env, jcharArray array, jsize start, jsize len, const jchar *buf);
+    SetShortArrayRegion::Ptr{Nothing} # void ( *SetShortArrayRegion ) (JNIEnv *env, jshortArray array, jsize start, jsize len, const jshort *buf);
+    SetIntArrayRegion::Ptr{Nothing} # void ( *SetIntArrayRegion) (JNIEnv *env, jintArray array, jsize start, jsize len, const jint *buf);
+    SetLongArrayRegion::Ptr{Nothing} # void ( *SetLongArrayRegion) (JNIEnv *env, jlongArray array, jsize start, jsize len, const jlong *buf);
+    SetFloatArrayRegion::Ptr{Nothing} # void ( *SetFloatArrayRegion ) (JNIEnv *env, jfloatArray array, jsize start, jsize len, const jfloat *buf);
+    SetDoubleArrayRegion::Ptr{Nothing} # void ( *SetDoubleArrayRegion) (JNIEnv *env, jdoubleArray array, jsize start, jsize len, const jdouble *buf);
+
+    RegisterNatives::Ptr{Nothing} # jint ( *RegisterNatives) (JNIEnv *env, jclass clazz, const JNINativeMethod *methods, jint nMethods);
+    UnregisterNatives::Ptr{Nothing} # jint ( *UnregisterNatives ) (JNIEnv *env, jclass clazz);
+
+    MonitorEnter::Ptr{Nothing} # jint ( *MonitorEnter) (JNIEnv *env, jobject obj);
+    MonitorExit::Ptr{Nothing} # jint ( *MonitorExit ) (JNIEnv *env, jobject obj);
+
+    GetJavaVM::Ptr{Nothing} # jint ( *GetJavaVM) (JNIEnv *env, JavaVM **vm);
+
+    GetStringRegion::Ptr{Nothing} # void ( *GetStringRegion ) (JNIEnv *env, jstring str, jsize start, jsize len, jchar *buf);
+    GetStringUTFRegion::Ptr{Nothing} # void ( *GetStringUTFRegion) (JNIEnv *env, jstring str, jsize start, jsize len, char *buf);
+
+    GetPrimitiveArrayCritical::Ptr{Nothing} # void * ( *GetPrimitiveArrayCritical) (JNIEnv *env, jarray array, jboolean *isCopy);
+    ReleasePrimitiveArrayCritical::Ptr{Nothing} # void ( *ReleasePrimitiveArrayCritical ) (JNIEnv *env, jarray array, void *carray, jint mode);
+
+    GetStringCritical::Ptr{Nothing} # const jchar * ( *GetStringCritical ) (JNIEnv *env, jstring string, jboolean *isCopy);
+    ReleaseStringCritical::Ptr{Nothing} # void ( *ReleaseStringCritical ) (JNIEnv *env, jstring string, const jchar *cstring);
+
+    NewWeakGlobalRef::Ptr{Nothing} # jweak ( *NewWeakGlobalRef) (JNIEnv *env, jobject obj);
+    DeleteWeakGlobalRef::Ptr{Nothing} # void ( *DeleteWeakGlobalRef) (JNIEnv *env, jweak ref);
+
+    ExceptionCheck::Ptr{Nothing} # jboolean ( *ExceptionCheck) (JNIEnv *env);
+
+    NewDirectByteBuffer::Ptr{Nothing} # jobject ( *NewDirectByteBuffer ) (JNIEnv* env, void* address, jlong capacity);
+    GetDirectBufferAddress::Ptr{Nothing} # void* ( *GetDirectBufferAddress ) (JNIEnv* env, jobject buf);
+    GetDirectBufferCapacity::Ptr{Nothing} # jlong ( *GetDirectBufferCapacity) (JNIEnv* env, jobject buf);
 
     #/* New JNI 1.6 Features */
 
-    GetObjectRefType::Ptr{Void} # jobjectRefType ( *GetObjectRefType) (JNIEnv* env, jobject obj);
+    GetObjectRefType::Ptr{Nothing} # jobjectRefType ( *GetObjectRefType) (JNIEnv* env, jobject obj);
 end #};
 
-immutable JNIEnv
+struct JNIEnv
     JNINativeInterface_::Ptr{JNINativeInterface}
 end
 
-immutable JNIInvokeInterface #struct JNIInvokeInterface_ {
-    reserved0::Ptr{Void} #void *reserved0;
-    reserved1::Ptr{Void} #vvoid *reserved1;
-    reserved2::Ptr{Void} #vvoid *reserved2;
+struct JNIInvokeInterface #struct JNIInvokeInterface_ {
+    reserved0::Ptr{Nothing} #void *reserved0;
+    reserved1::Ptr{Nothing} #vvoid *reserved1;
+    reserved2::Ptr{Nothing} #vvoid *reserved2;
 
-    DestroyJavaVM::Ptr{Void} #jint (JNICALL *DestroyJavaVM)(JavaVM *vm);
+    DestroyJavaVM::Ptr{Nothing} #jint (JNICALL *DestroyJavaVM)(JavaVM *vm);
 
-    AttachCurrentThread::Ptr{Void} #jint (JNICALL *AttachCurrentThread)(JavaVM *vm, void **penv, void *args);
+    AttachCurrentThread::Ptr{Nothing} #jint (JNICALL *AttachCurrentThread)(JavaVM *vm, void **penv, void *args);
 
-    DetachCurrentThread::Ptr{Void} #jint (JNICALL *DetachCurrentThread)(JavaVM *vm);
+    DetachCurrentThread::Ptr{Nothing} #jint (JNICALL *DetachCurrentThread)(JavaVM *vm);
 
-    GetEnv::Ptr{Void} #jint (JNICALL *GetEnv)(JavaVM *vm, void **penv, jint version);
+    GetEnv::Ptr{Nothing} #jint (JNICALL *GetEnv)(JavaVM *vm, void **penv, jint version);
 
-    AttachCurrentThreadAsDaemon::Ptr{Void} #jint (JNICALL *AttachCurrentThreadAsDaemon)(JavaVM *vm, void **penv, void *args);
+    AttachCurrentThreadAsDaemon::Ptr{Nothing} #jint (JNICALL *AttachCurrentThreadAsDaemon)(JavaVM *vm, void **penv, void *args);
 end
 
-immutable JavaVM
+struct JavaVM
     JNIInvokeInterface_::Ptr{JNIInvokeInterface}
 end
 

--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -161,9 +161,7 @@ assertnotloaded() = isloaded() ? @error("JVM already initialised") : nothing
 # Pointer to pointer to pointer to pointer alert! Hurrah for unsafe load
 function init(opts)
     assertnotloaded()
-    # TODO THIS IS A HACK WHILE DataStructures.jl gets fixed!
-    # opt = [JavaVMOption(pointer(x), C_NULL) for x in opts]
-    opt = JavaVMOption[]
+    opt = [JavaVMOption(pointer(x), C_NULL) for x in opts]
     ppjvm = Array{Ptr{JavaVM}}(undef, 1)
     ppenv = Array{Ptr{JNIEnv}}(undef, 1)
     vm_args = JavaVMInitArgs(JNI_VERSION_1_6, convert(Cint, length(opts)),

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -79,7 +79,7 @@ function listmethods(obj::JavaObject)
     jcall(cls, "getMethods", Vector{JMethod}, ())
 end
 
-function listmethods{C}(::Type{JavaObject{C}})
+function listmethods(::Type{JavaObject{C}}) where C
     cls = classforname(string(C))
     jcall(cls, "getMethods", Vector{JMethod}, ())
 end
@@ -102,7 +102,7 @@ Lists the methods that are available on the java object passed. The methods are 
 ### Returns
 List of methods available on the java object and matching the name passed
 """
-function listmethods{C}(obj::Union{JavaObject{C}, Type{JavaObject{C}}}, name::AbstractString)
+function listmethods(obj::Union{JavaObject{C}, Type{JavaObject{C}}}, name::AbstractString) where C
     allmethods = listmethods(obj)
     filter(m -> getname(m) == name, allmethods)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,9 @@ if VERSION ≥ v"0.7-"
 end
 
 
-# JavaCall.init(["-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
+JavaCall.init(["-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
 # JavaCall.init(["-verbose:gc","-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
-JavaCall.init()
+# JavaCall.init()
 
 @testset "unsafe_strings_1" begin
     a=JString("how are you")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,8 @@ if VERSION ≥ v"0.7-"
 end
 
 
-JavaCall.init(["-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
-# JavaCall.init(["-verbose:gc","-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
+JavaCall.init(["-Djava.class.path=$(@__DIR__)"])
+# JavaCall.init(["-verbose:gc","-Djava.class.path=$(@__DIR__)"])
 # JavaCall.init()
 
 @testset "unsafe_strings_1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,131 +1,144 @@
-using Base.Test
+using Compat, Compat.Test
 using JavaCall
 
+if VERSION ≥ v"0.7-"
+    import Pkg
+    import Dates
+    using Base.GC: gc
+end
 
-versioninfo();
 
 # JavaCall.init(["-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
-JavaCall.init(["-verbose:gc","-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
+# JavaCall.init(["-verbose:gc","-Djava.class.path=$(joinpath(Pkg.dir(), "JavaCall", "test"))"])
+JavaCall.init()
 
-a=JString("how are you")
-@test a.ptr != C_NULL
-@test 11==ccall(JavaCall.jnifunc.GetStringUTFLength, jint, (Ptr{JavaCall.JNIEnv}, Ptr{Void}), JavaCall.penv, a.ptr)
-b=ccall(JavaCall.jnifunc.GetStringUTFChars, Ptr{UInt8}, (Ptr{JavaCall.JNIEnv}, Ptr{Void}, Ptr{Void}), JavaCall.penv, a.ptr, C_NULL)
-@test unsafe_string(b) == "how are you"
+@testset "unsafe_strings_1" begin
+    a=JString("how are you")
+    @test a.ptr != C_NULL
+    @test 11 == ccall(JavaCall.jnifunc.GetStringUTFLength, jint, (Ptr{JavaCall.JNIEnv}, Ptr{Nothing}),
+                      JavaCall.penv, a.ptr)
+    b = ccall(JavaCall.jnifunc.GetStringUTFChars, Ptr{UInt8},
+              (Ptr{JavaCall.JNIEnv}, Ptr{Nothing}, Ptr{Nothing}), JavaCall.penv, a.ptr, C_NULL)
+    @test unsafe_string(b) == "how are you"
+end
 
-# Test parameter passing
 T = @jimport Test
-@test 10 == jcall(T, "testShort", jshort, (jshort,), 10)
-@test 10 == jcall(T, "testInt", jint, (jint,), 10)
-@test 10 == jcall(T, "testLong", jlong, (jlong,), 10)
-@test typemax(jint) == jcall(T, "testInt", jint, (jint,), typemax(jint))
-@test typemax(jlong) == jcall(T, "testLong", jlong, (jlong,), typemax(jlong))
-@test "Hello Java"==jcall(T, "testString", JString, (JString,), "Hello Java")
-@test Float64(10.02) == jcall(T, "testDouble", jdouble, (jdouble,), 10.02) #Comparing exact float representations hence ==
-@test Float32(10.02) == jcall(T, "testFloat", jfloat, (jfloat,), 10.02)
-@test realmax(jdouble) == jcall(T, "testDouble", jdouble, (jdouble,), realmax(jdouble))
-@test realmax(jfloat) == jcall(T, "testFloat", jfloat, (jfloat,), realmax(jfloat))
 
-c=JString(C_NULL)
-@test isnull(c)
-@test "" == jcall(T, "testString", JString, (JString,), c)
+@testset "parameter_passing_1" begin
+    @test 10 == jcall(T, "testShort", jshort, (jshort,), 10)
+    @test 10 == jcall(T, "testInt", jint, (jint,), 10)
+    @test 10 == jcall(T, "testLong", jlong, (jlong,), 10)
+    @test typemax(jint) == jcall(T, "testInt", jint, (jint,), typemax(jint))
+    @test typemax(jlong) == jcall(T, "testLong", jlong, (jlong,), typemax(jlong))
+    @test "Hello Java"==jcall(T, "testString", JString, (JString,), "Hello Java")
+    @test Float64(10.02) == jcall(T, "testDouble", jdouble, (jdouble,), 10.02) #Comparing exact float representations hence ==
+    @test Float32(10.02) == jcall(T, "testFloat", jfloat, (jfloat,), 10.02)
+    @test realmax(jdouble) == jcall(T, "testDouble", jdouble, (jdouble,), realmax(jdouble))
+    @test realmax(jfloat) == jcall(T, "testFloat", jfloat, (jfloat,), realmax(jfloat))
+    c=JString(C_NULL)
+    @test isnull(c)
+    @test "" == jcall(T, "testString", JString, (JString,), c)
+end
 
-# Test calling static methods
-jlm = @jimport "java.lang.Math"
-@test 1.0 ≈ jcall(jlm, "sin", jdouble, (jdouble,), pi/2)
-@test 1.0 ≈ jcall(jlm, "min", jdouble, (jdouble,jdouble), 1,2)
-@test 1 == jcall(jlm, "abs", jint, (jint,), -1)
+@testset "static_method_call_1" begin
+    jlm = @jimport "java.lang.Math"
+    @test 1.0 ≈ jcall(jlm, "sin", jdouble, (jdouble,), pi/2)
+    @test 1.0 ≈ jcall(jlm, "min", jdouble, (jdouble,jdouble), 1,2)
+    @test 1 == jcall(jlm, "abs", jint, (jint,), -1)
+end
 
-#Test instance creation
-jnu = @jimport java.net.URL
-gurl = jnu((JString,), "http://www.google.com")
-@test "www.google.com"==jcall(gurl, "getHost", JString,())
+@testset "instance_methods_1" begin
+    jnu = @jimport java.net.URL
+    gurl = jnu((JString,), "https://en.wikipedia.org")
+    @test "en.wikipedia.org"==jcall(gurl, "getHost", JString,())
+    jni = @jimport java.net.URI
+    guri=jcall(gurl, "toURI", jni,())
+    @test typeof(guri)==jni
 
-#Test instance methods
-jni=@jimport java.net.URI
-guri=jcall(gurl, "toURI", jni,())
-@test typeof(guri)==jni
-
-h=jcall(guri, "hashCode", jint,())
-typeof(h)==jint
+    h=jcall(guri, "hashCode", jint,())
+    @test typeof(h)==jint
+end
 
 #Test NULL
-H=@jimport java.util.HashMap
-a=jcall(T, "testNull", H, ())
-@test_throws ErrorException jcall(a, "toString", JString, ())
+@testset "null_1" begin
+    H=@jimport java.util.HashMap
+    a=jcall(T, "testNull", H, ())
+    @test_throws ErrorException jcall(a, "toString", JString, ())
+end
 
-# Arrays
-j_u_arrays = @jimport java.util.Arrays
-@test 3 == jcall(j_u_arrays, "binarySearch", jint, (Array{jint,1}, jint), [10,20,30,40,50,60], 40)
-@test 2 == jcall(j_u_arrays, "binarySearch", jint, (Array{JObject,1}, JObject), ["123","abc","uvw","xyz"], "uvw")
+@testset "arrays_1" begin
+    j_u_arrays = @jimport java.util.Arrays
+    @test 3 == jcall(j_u_arrays, "binarySearch", jint, (Array{jint,1}, jint), [10,20,30,40,50,60], 40)
+    @test 2 == jcall(j_u_arrays, "binarySearch", jint, (Array{JObject,1}, JObject), ["123","abc","uvw","xyz"], "uvw")
 
-a=jcall(j_u_arrays, "copyOf", Array{jint, 1}, (Array{jint, 1}, jint), [1,2,3], 3)
-@test typeof(a) == Array{jint, 1}
-@test a[1] == Int32(1)
-@test a[2] == Int32(2)
-@test a[3] == Int32(3)
+    a=jcall(j_u_arrays, "copyOf", Array{jint, 1}, (Array{jint, 1}, jint), [1,2,3], 3)
+    @test typeof(a) == Array{jint, 1}
+    @test a[1] == Int32(1)
+    @test a[2] == Int32(2)
+    @test a[3] == Int32(3)
 
-a=jcall(j_u_arrays, "copyOf", Array{JObject, 1}, (Array{JObject, 1}, jint), ["a","b","c"], 3)
-@test 3==length(a)
-@test "a"==unsafe_string(convert(JString, a[1]))
-@test "b"==unsafe_string(convert(JString, a[2]))
-@test "c"==unsafe_string(convert(JString, a[3]))
+    a=jcall(j_u_arrays, "copyOf", Array{JObject, 1}, (Array{JObject, 1}, jint), ["a","b","c"], 3)
+    @test 3==length(a)
+    @test "a"==unsafe_string(convert(JString, a[1]))
+    @test "b"==unsafe_string(convert(JString, a[2]))
+    @test "c"==unsafe_string(convert(JString, a[3]))
 
-@test jcall(T, "testDoubleArray", Array{jdouble,1}, ()) == [0.1, 0.2, 0.3]
-@test jcall(T, "testDoubleArray2D", Array{Array{jdouble, 1},1}, ()) == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
-@test jcall(T, "testDoubleArray2D", Array{jdouble,2}, ()) == [0.1 0.2 0.3; 0.4 0.5 0.6]
-@test size(jcall(T, "testStringArray2D", Array{JString,2}, ())) == (2,2)
+    @test jcall(T, "testDoubleArray", Array{jdouble,1}, ()) == [0.1, 0.2, 0.3]
+    @test jcall(T, "testDoubleArray2D", Array{Array{jdouble, 1},1}, ()) == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    @test jcall(T, "testDoubleArray2D", Array{jdouble,2}, ()) == [0.1 0.2 0.3; 0.4 0.5 0.6]
+    @test size(jcall(T, "testStringArray2D", Array{JString,2}, ())) == (2,2)
+end
 
+@testset "dates_1" begin
+    jd = @jimport(java.util.Date)(())
+    jcal = @jimport(java.util.GregorianCalendar)(())
+    jsd =  @jimport(java.sql.Date)((jlong,),round(jlong, time()))
 
-#Test for Dates
+    @test typeof(convert(Dates.DateTime, jd)) == Dates.DateTime
+    @test typeof(convert(Dates.DateTime, jcal)) == Dates.DateTime
+    @test typeof(convert(Dates.DateTime, jsd)) == Dates.DateTime
+    nulldate = @jimport(java.util.Date)(C_NULL)
+    @test Dates.year(convert(Dates.DateTime, nulldate)) == 1970
+    nullcal = @jimport(java.util.GregorianCalendar)(C_NULL)
+    @test Dates.year(convert(Dates.DateTime, nullcal)) == 1970
 
-jd = @jimport(java.util.Date)(())
-jcal = @jimport(java.util.GregorianCalendar)(())
-jsd =  @jimport(java.sql.Date)((jlong,),round(jlong, time()))
+    @test Dates.year(convert(Dates.DateTime, nullcal)) == 1970
+end
 
-@assert typeof(convert(Dates.DateTime, jd)) == Dates.DateTime
-@assert typeof(convert(Dates.DateTime, jcal)) == Dates.DateTime
-@assert typeof(convert(Dates.DateTime, jsd)) == Dates.DateTime
-nulldate = @jimport(java.util.Date)(C_NULL)
-@assert Dates.year(convert(Dates.DateTime, nulldate)) == 1970
-nullcal = @jimport(java.util.GregorianCalendar)(C_NULL)
-@assert Dates.year(convert(Dates.DateTime, nullcal)) == 1970
+@testset "map_conversion_1" begin
+    JHashMap = @jimport(java.util.HashMap)
+    p = JHashMap(())
+    a= Dict("a"=>"A", "b"=>"B")
+    b=convert(@jimport(java.util.Map), JString, JString, a)
+    @test jcall(b, "size", jint, ()) == 2
+end
 
-Dates.year(convert(Dates.DateTime, nullcal)) == 1970
-#Test for Map conversion
+@testset "array_list_conversion_1" begin
+    JArrayList = @jimport(java.util.ArrayList)
+    p = JArrayList(())
+    a = ["hello", " ", "world"]
+    b = convert(@jimport(java.util.ArrayList), a, JString)
+    @test jcall(b, "size", jint, ()) == 3
+end
 
-JHashMap = @jimport(java.util.HashMap)
-p = JHashMap(())
-a= Dict("a"=>"A", "b"=>"B")
-b=convert(@jimport(java.util.Map), JString, JString, a)
-@assert jcall(b, "size", jint, ()) == 2
-
-# test for ArrayList conversion
-JArrayList = @jimport(java.util.ArrayList)
-p = JArrayList(())
-a = ["hello", " ", "world"]
-b = convert(@jimport(java.util.ArrayList), a, JString)
-@assert jcall(b, "size", jint, ()) == 3
-
-#Inner Classes
-TestInner = @jimport(Test$TestInner)
-Test = @jimport(Test)
-t=Test(())
-inner = TestInner((Test,), t)
-@assert jcall(inner, "innerString", JString, ()) == "from inner"
-
-#Static Field Access
-@assert jfield(@jimport(java.lang.Math), "E", jdouble) == 2.718281828459045
-@assert jfield(@jimport(java.lang.Math), "PI", jdouble) == 3.141592653589793
-@assert jfield(@jimport(java.text.NumberFormat), "INTEGER_FIELD", jint) == 0
-Locale = @jimport java.util.Locale
-lc = jfield(@jimport(java.util.Locale), "CANADA", @jimport(java.util.Locale))
-#Instance field access
-#Disabled for now. Need to verify stability
-@assert jfield(@jimport(java.util.logging.Logger), "GLOBAL_LOGGER_NAME", JString ) == "global"
-@assert jcall(lc, "getCountry", JString, ()) == "CA"
-@assert jfield(t, "integerField", jint) == 100
-@assert jfield(t, "stringField", JString) == "A STRING"
+@testset "inner_classes_1" begin
+    TestInner = @jimport(Test$TestInner)
+    Test = @jimport(Test)
+    t=Test(())
+    inner = TestInner((Test,), t)
+    @test jcall(inner, "innerString", JString, ()) == "from inner"
+    @test jfield(@jimport(java.lang.Math), "E", jdouble) == 2.718281828459045
+    @test jfield(@jimport(java.lang.Math), "PI", jdouble) == 3.141592653589793
+    @test jfield(@jimport(java.text.NumberFormat), "INTEGER_FIELD", jint) == 0
+    Locale = @jimport java.util.Locale
+    lc = jfield(@jimport(java.util.Locale), "CANADA", @jimport(java.util.Locale))
+    #Instance field access
+    #Disabled for now. Need to verify stability
+    @test jfield(@jimport(java.util.logging.Logger), "GLOBAL_LOGGER_NAME", JString ) == "global"
+    @test jcall(lc, "getCountry", JString, ()) == "CA"
+    @test jfield(t, "integerField", jint) == 100
+    @test jfield(t, "stringField", JString) == "A STRING"
+end
 
 # Test Memory allocation and de-allocatios
 # the following loop fails with an OutOfMemoryException in the absence of de-allocation
@@ -136,88 +149,93 @@ for i in 1:100000
 	if (i%10000 == 0); gc(); end
 end
 
-#Test for Issue #8
-@test_throws ErrorException jcall(jlm, "sinx", jdouble, (jdouble,), 1.0)
-@test_throws ErrorException jcall(jlm, "sinx", jdouble, (jdouble,), 1.0)
+@testset "sinx_1" begin
+    @test_throws UndefVarError jcall(jlm, "sinx", jdouble, (jdouble,), 1.0)
+    @test_throws UndefVarError jcall(jlm, "sinx", jdouble, (jdouble,), 1.0)
+end
 
-@test length(listmethods(JString("test"))) >= 72
-@test length(listmethods(JString("test"), "indexOf")) >= 3
-# the same for the type
-@test length(listmethods(JString)) >= 72
-@test length(listmethods(JString, "indexOf")) >= 3
-# the same for class
-@test length(listmethods(getclass(JString("test")))) >= 72
-@test length(listmethods(getclass(JString("test")), "indexOf")) >= 3
-m = listmethods(JString("test"), "indexOf")[1]
-@test getname(getreturntype(m)) == "int"
+@testset "method_lists_1" begin
+    @test length(listmethods(JString("test"))) >= 72
+    @test length(listmethods(JString("test"), "indexOf")) >= 3
+    # the same for the type
+    @test length(listmethods(JString)) >= 72
+    @test length(listmethods(JString, "indexOf")) >= 3
+    # the same for class
+    @test length(listmethods(getclass(JString("test")))) >= 72
+    @test length(listmethods(getclass(JString("test")), "indexOf")) >= 3
+    m = listmethods(JString("test"), "indexOf")[1]
+    @test getname(getreturntype(m)) == "int"
 
-v=jcall(@jimport("java.lang.System"), "getProperty", JString, (JString,), "java.version")
-v=replace(v, '_', '-')
-java_ver = macroexpand(:(@v_str($v)))
+    v=jcall(@jimport("java.lang.System"), "getProperty", JString, (JString,), "java.version")
+    v=replace(v, "_"=>"-")
+    java_ver = macroexpand(Main, :(@v_str($v)))
 
-#Order of methods is different in JDK 9
-if java_ver < v"9"
-    @test [getname(typ) for typ in getparametertypes(m)] == ["java.lang.String", "int"]
-else
-    @test [getname(typ) for typ in getparametertypes(m)] == ["int"]
+    #Order of methods is different in JDK 9
+    if java_ver < v"9.0.0-"
+        @test [getname(typ) for typ in getparametertypes(m)] == ["java.lang.String", "int"]
+    else
+        @test [getname(typ) for typ in getparametertypes(m)] == ["int"]
+    end
 end
 
 #Test for double free bug, #20
 #Fix in #28. The following lines will segfault without the fix
-JHashtable = @jimport java.util.Hashtable
-JProperties = @jimport java.util.Properties
-ta_20=Any[]
-for i=1:100; push!(ta_20, convert(JHashtable, JProperties((),))); end
-gc(); gc()
-for i=1:100; @test jcall(ta_20[i], "size", jint, ()) == 0; end
-
-# Test array conversions
-jobj = jcall(T, "testArrayAsObject", JObject, ())
-arr = convert(Array{Array{UInt8, 1}, 1}, jobj)
-@test ["Hello", "World"] == map(String, arr)
-
-#Test iterator conversions
-
-JArrayList = @jimport(java.util.ArrayList)
-a=JArrayList(())
-jcall(a, "add", jboolean, (JObject,), "abc")
-jcall(a, "add", jboolean, (JObject,), "cde")
-jcall(a, "add", jboolean, (JObject,), "efg")
-
-t=Array{Any, 1}()
-for i in JavaCall.iterator(a)
-	push!(t, unsafe_string(i))
+@testset "double_free_1" begin
+    JHashtable = @jimport java.util.Hashtable
+    JProperties = @jimport java.util.Properties
+    ta_20=Any[]
+    for i=1:100; push!(ta_20, convert(JHashtable, JProperties((),))); end
+    gc(); gc()
+    for i=1:100; @test jcall(ta_20[i], "size", jint, ()) == 0; end
 end
 
-@test length(t) == 3
-@test t[1] == "abc"
-@test t[2] == "cde"
-@test t[3] == "efg"
-
-#Different iterator type - ListIterator
-t=Array{Any, 1}()
-for i in jcall(a, "listIterator", @jimport(java.util.ListIterator), ())
-	push!(t, unsafe_string(i))
+@testset "array_conversions_1" begin
+    jobj = jcall(T, "testArrayAsObject", JObject, ())
+    arr = convert(Array{Array{UInt8, 1}, 1}, jobj)
+    @test ["Hello", "World"] == map(String, arr)
 end
 
-@test length(t) == 3
-@test t[1] == "abc"
-@test t[2] == "cde"
-@test t[3] == "efg"
+@testset "iterator_conversions_1" begin
+    JArrayList = @jimport(java.util.ArrayList)
+    a=JArrayList(())
+    jcall(a, "add", jboolean, (JObject,), "abc")
+    jcall(a, "add", jboolean, (JObject,), "cde")
+    jcall(a, "add", jboolean, (JObject,), "efg")
 
-#Empty List
-a=JArrayList(())
-t=Array{Any, 1}()
-for i in JavaCall.iterator(a)
-	push!(t, unsafe_string(i))
+    t=Array{Any, 1}()
+    for i in JavaCall.iterator(a)
+        push!(t, unsafe_string(i))
+    end
+
+    @test length(t) == 3
+    @test t[1] == "abc"
+    @test t[2] == "cde"
+    @test t[3] == "efg"
+
+    #Different iterator type - ListIterator
+    t=Array{Any, 1}()
+    for i in jcall(a, "listIterator", @jimport(java.util.ListIterator), ())
+        push!(t, unsafe_string(i))
+    end
+
+    @test length(t) == 3
+    @test t[1] == "abc"
+    @test t[2] == "cde"
+    @test t[3] == "efg"
+
+    a=JArrayList(())
+    t=Array{Any, 1}()
+    for i in JavaCall.iterator(a)
+        push!(t, unsafe_string(i))
+    end
+    @test length(t) == 0
+
+    JStringClass = classforname("java.lang.String")
+    @test isa(JStringClass, JavaObject{Symbol("java.lang.Class")})
+
+    o = convert(JObject, "bla bla bla")
+    @test isa(narrow(o), JString)
 end
-@test length(t) == 0
-
-JStringClass = classforname("java.lang.String")
-@test isa(JStringClass, JavaObject{Symbol("java.lang.Class")})
-
-o = convert(JObject, "bla bla bla")
-@test isa(narrow(o), JString)
 
 
 # At the end, unload the JVM before exiting


### PR DESCRIPTION
Ok, this is a complete overhaul for 0.7.  I have maintained compatibility with 0.6, but dropped compatibility with 0.5.  I've also modernized "runtests.jl".

There were quite a few changes here, so I took the opportunity to clean up some code that I found messy or hard to read.  Of course this is very subjective, so hopefully I didn't go overboard on that account.  The only real change in functionality here is that `@jlimport` now also filters out `(` and `)` characters from its arguments, since in 0.7 Julia will insert those automatically to `getproperty` calls, and Java really doesn't like that.  I took the opportunity to rewrite `@jlimport` slightly to utilize proper multiple dispatch which as been availble on macros since at least 0.6.

On a side note, with this update JDBC should be good-to-go on 0.7.