### PR TITLE
some slightly better error handling

### DIFF
--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -13,7 +13,7 @@ using Compat.Sys: iswindows, islinux, isunix, isapple
 import DataStructures: OrderedSet
 
 if VERSION < v"0.7-"
-    using Compat: @warn, @error
+    using Compat: @warn
     import Base: isnull
     Base.finalizer(f::Function, o) = Base.finalizer(o, f)
 else

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -8,14 +8,14 @@ function convert(::Type{JavaObject{T}}, obj::JavaObject{S}) where {T,S}
         ptr === C_NULL && geterror()
         return JavaObject{T}(ptr)
     end
-    isnull(obj) && @error("Cannot convert NULL")
+    isnull(obj) && throw(ArgumentError("Cannot convert NULL"))
     realClass = ccall(jnifunc.GetObjectClass, Ptr{Nothing}, (Ptr{JNIEnv}, Ptr{Nothing} ), penv, obj.ptr)
     if isConvertible(T, realClass)  #dynamic cast
         ptr = ccall(jnifunc.NewLocalRef, Ptr{Nothing}, (Ptr{JNIEnv}, Ptr{Nothing}), penv, obj.ptr)
         ptr === C_NULL && geterror()
         return JavaObject{T}(ptr)
     end
-    @error("Cannot cast java object from $S to $T")
+    throw(JavaCallError("Cannot cast java object from $S to $T"))
 end
 
 #Is java type convertible from S to T.

--- a/src/jnienv.jl
+++ b/src/jnienv.jl
@@ -329,4 +329,6 @@ struct JavaVM
     JNIInvokeInterface_::Ptr{JNIInvokeInterface}
 end
 
-
+struct JavaCallError <: Exception
+    msg::String
+end


### PR DESCRIPTION
This was done quickly and without much care, but I added a `JavaCallError` and replaced most of the error calls with `throw(JavaCallError(str))`.

This should fix the issue where `@error` wasn't throwing errors in the places where originally intended and also do a tiny bit to pave the way for more proper error handling (i.e. coexistence of Julia and Java errors).