### PR TITLE
improvedi `libjvm` discovery

### DIFF
--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -16,8 +16,6 @@ const JNI_ENOMEM       = convert(Cint, -4)              #/* not enough memory */
 const JNI_EEXIST       = convert(Cint, -5)              #/* VM already created */
 const JNI_EINVAL       = convert(Cint, -6)              #/* invalid arguments */
 
-const LIBEXEC_JAVA_HOME = "/usr/libexec/java_home"
-
 const JAVA_HOME_CANDIDATES = ["/usr/lib/jvm/default-java/",
                               "/usr/lib/jvm/default/"]
 
@@ -53,7 +51,7 @@ function findjvm()
             push!(javahomes, ENV["JAVA_HOME"])
         end
     end
-    isfile(LIBEXEC_JAVA_HOME) && push!(javahomes, chomp(read(LIBEXEC_JAVA_HOME, String)))
+    isfile("/usr/libexec/java_home") && push!(javahomes, chomp(read(`/usr/libexec/java_home`, String)))
 
     for fname ∈ JAVA_HOME_CANDIDATES
         isdir(fname) && push!(javahomes, fname)
@@ -93,7 +91,7 @@ function findjvm()
                     Libdl.dlopen(joinpath(bindir,m[1]))
                 end
                 global libjvm = Libdl.dlopen(libpath)
-                @info("Loaded $libpath")
+                @debug("Loaded $libpath")
                 return
             end
         end

--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -16,8 +16,9 @@ const JNI_ENOMEM       = convert(Cint, -4)              #/* not enough memory */
 const JNI_EEXIST       = convert(Cint, -5)              #/* VM already created */
 const JNI_EINVAL       = convert(Cint, -6)              #/* invalid arguments */
 
-const JAVA_HOME_CANDIDATES = ["/usr/libexec/java_home/",
-                              "/usr/lib/jvm/default-java/",
+const LIBEXEC_JAVA_HOME = "/usr/libexec/java_home"
+
+const JAVA_HOME_CANDIDATES = ["/usr/lib/jvm/default-java/",
                               "/usr/lib/jvm/default/"]
 
 function javahome_winreg()
@@ -44,13 +45,15 @@ function findjvm()
     javahomes = Any[]
     libpaths = Any[]
 
-    if haskey(ENV,"JAVA_HOME")
-        push!(javahomes,ENV["JAVA_HOME"])
-    end
-    @static if Sys.iswindows()
-        ENV["JAVA_HOME"] = javahome_winreg()
+    if haskey(ENV, "JAVA_HOME")
         push!(javahomes, ENV["JAVA_HOME"])
+    else
+        @static if Sys.iswindows()
+            ENV["JAVA_HOME"] = javahome_winreg()
+            push!(javahomes, ENV["JAVA_HOME"])
+        end
     end
+    isfile(LIBEXEC_JAVA_HOME) && push!(javahomes, chomp(read(LIBEXEC_JAVA_HOME, String)))
 
     for fname ∈ JAVA_HOME_CANDIDATES
         isdir(fname) && push!(javahomes, fname)

--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -16,6 +16,10 @@ const JNI_ENOMEM       = convert(Cint, -4)              #/* not enough memory */
 const JNI_EEXIST       = convert(Cint, -5)              #/* VM already created */
 const JNI_EINVAL       = convert(Cint, -6)              #/* invalid arguments */
 
+const JAVA_HOME_CANDIDATES = ["/usr/libexec/java_home/",
+                              "/usr/lib/jvm/default-java/",
+                              "/usr/lib/jvm/default/"]
+
 function javahome_winreg()
     try
         keypath = "SOFTWARE\\JavaSoft\\Java Runtime Environment"
@@ -42,17 +46,14 @@ function findjvm()
 
     if haskey(ENV,"JAVA_HOME")
         push!(javahomes,ENV["JAVA_HOME"])
-    else
-        @static Sys.iswindows() ? ENV["JAVA_HOME"] = javahome_winreg() : nothing
-        @static Sys.iswindows() ? push!(javahomes, ENV["JAVA_HOME"]) : nothing
+    end
+    @static if Sys.iswindows()
+        ENV["JAVA_HOME"] = javahome_winreg()
+        push!(javahomes, ENV["JAVA_HOME"])
     end
 
-    if isfile("/usr/libexec/java_home")
-        push!(javahomes,chomp(read(`/usr/libexec/java_home`, String)))
-    end
-
-    if isdir("/usr/lib/jvm/default-java/")
-        push!(javahomes, "/usr/lib/jvm/default-java/")
+    for fname ∈ JAVA_HOME_CANDIDATES
+        isdir(fname) && push!(javahomes, fname)
     end
 
     push!(libpaths, pwd())
@@ -70,8 +71,8 @@ function findjvm()
                 push!(libpaths, joinpath(n, "jre", "lib", "i386", "server"))
 
                 push!(libpaths, joinpath(n, "lib", "i386", "server"))
-             end
-         end
+            end
+        end
         push!(libpaths, joinpath(n, "jre", "lib", "server"))
         push!(libpaths, joinpath(n, "lib", "server"))
     end
@@ -89,7 +90,7 @@ function findjvm()
                     Libdl.dlopen(joinpath(bindir,m[1]))
                 end
                 global libjvm = Libdl.dlopen(libpath)
-                println("Loaded $libpath")
+                @info("Loaded $libpath")
                 return
             end
         end


### PR DESCRIPTION
Hello all.  I've cleaned up the JVM discovery a bit.  First, the standard `JAVA_HOME` locations are now stored in the global constant `JAVA_HOME_CANDIDATES`, making it slightly easier and more transparent for future committers to put new directories there.  Additionally, I have added the directory `/usr/lib/jvm/default` to these, which is the default `JAVA_HOME` on Arch linux (pretty sure this is the standard for modern Java on modern linux distros).

Lastly, the message that tells the user that `libjvm.so` has been loaded has been changed to `@info` so that it can be controlled with logging.  Is there any interest in removing this message entirely?  It seems a little pedantic to tell the user that you are loading the JVM library when JavaCall is loaded, I mean of course it has to load a library.  The only disadvantage I can see of removing that message is that (as I found out the hardway) if you do `@everywhere using JavaCall` you will of course load many instances of the library.  Still, I'd vote to remove the message.