### PR TITLE
Add some useful ENV

### DIFF
--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -150,6 +150,16 @@ end
 addOpts(s::String) = isloaded() ? @warn("JVM already initialised. This call has no effect") : push!(opts, s)
 
 function init()
+    if haskey(ENV, "JAVACALL_IGNORE_WORKERS")
+        v = ENV["JAVACALL_IGNORE_WORKERS"]
+        if myid() in map(x->parse(Int, x), split(v, ","))
+            warn("Not initializing JavaCall")
+            return
+        end
+    end
+    if haskey(ENV, "JAVACALL_MEMORY_LIMIT")
+        addOpts("-Xmx$(ENV["JAVACALL_MEMORY_LIMIT"])")
+    end
     if isempty(cp)
         init(opts)
     else


### PR DESCRIPTION
* `JAVACALL_IGNORE_WORKERS`: If `myid()` is in this list then JVM is not initialized. This is useful when you don't want JVM to load on certain workers.
* `JAVACALL_MEMORY_LIMIT`: This is the heap size limit.