### PR TITLE
added warning in case of unset JULIA_COPY_STACKS variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JavaCall"
 uuid = "494afd89-becb-516b-aafa-70d2670c0337"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-DataStructures
-@windows WinReg

--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -152,6 +152,10 @@ end
 addOpts(s::String) = isloaded() ? @warn("JVM already initialised. This call has no effect") : push!(opts, s)
 
 function init()
+    if get(ENV, "JULIA_COPY_STACKS", "") ∉ ("1", "yes")
+        @warn("JavaCall needs the environment variable `JULIA_COPY_STACKS` to be `1` or `yes`. "*
+              "Calling the JVM may result in undefined behavior.")
+    end
     if isempty(cp)
         init(opts)
     else

--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -152,7 +152,7 @@ end
 addOpts(s::String) = isloaded() ? @warn("JVM already initialised. This call has no effect") : push!(opts, s)
 
 function init()
-    if get(ENV, "JULIA_COPY_STACKS", "") ∉ ("1", "yes")
+    if VERSION ≥ v"1.3" && get(ENV, "JULIA_COPY_STACKS", "") ∉ ("1", "yes")
         @warn("JavaCall needs the environment variable `JULIA_COPY_STACKS` to be `1` or `yes`. "*
               "Calling the JVM may result in undefined behavior.")
     end


### PR DESCRIPTION
Seems pretty silly of us not to have had this already.

Current behavior might be pretty bewildering to anyone who's not constantly reading Julia discourse or Slack, which is not at all ideal.

I also took this opportunity to delete the long since deprecated `REQUIRE` file.

Currently the behavior with unset `JULIA_COPY_STACKS` is so bad that perhaps we should even consider throwing an explicit exception here.