### PR TITLE
OS agnostic addClassPath

### DIFF
--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -151,12 +151,12 @@ function addClassPath(s::String)
         return
     end
     if s==""; return; end
-    if  endswith(s, "$(Base.Filesystem.path_separator)*.jar")
-        s=s[1:end-4]; # make it end with ".*" instead
-    end
-    if (endswith(s, "$(Base.Filesystem.path_separator)*") && isdir(s[1:end-2]))
-        for x in s[1:end-1] .* readdir(s[1:end-2])
-            endswith(x, ".jar") && push!(cp, x)
+    dirname, pattern = splitdir(s)
+    if pattern in ("*","*.jar") && isdir(dirname)
+        for filename in readdir(dirname)
+            if endswith(filename,".jar")
+                push!(cp, joinpath(dirname,filename))
+            end
         end
         return
     end


### PR DESCRIPTION
This is an update of #89 that avoids the use of the undocumented `Base.Filesystem.path_separator` but instead uses `splitdir` and `joinpath` to constructed a path on either Windows or *nix