### PR TITLE
Add a no argument constructor for JavaObjects

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -39,6 +39,7 @@ mutable struct JavaObject{T}
 end
 
 JavaObject(T, ptr) = JavaObject{T}(ptr)
+JavaObject{T}() where {T} = JavaObject{T}((),)
 
 function deleteref(x::JavaObject)
     if x.ptr == C_NULL; return; end


### PR DESCRIPTION
This change makes it easier to construct objects that require no arguments.

```
julia> using JavaCall
[ Info: Precompiling JavaCall [494afd89-becb-516b-aafa-70d2670c0337]
┌ Warning: JavaCall needs the environment variable `JULIA_COPY_STACKS` to be `1` or `yes`.
│ Calling the JVM may result in undefined behavior.
└ @ JavaCall ~/.julia/dev/JavaCall/src/JavaCall.jl:42

julia> JavaCall.addClassPath.(["jars/*","plugins/*"]); JavaCall.init()

julia> ImageJ2 = @jimport net.imagej.ImageJ
JavaObject{Symbol("net.imagej.ImageJ")}

julia> ImageJ1 = @jimport ij.ImageJ
JavaObject{Symbol("ij.ImageJ")}

julia> ImageJ2()
JavaObject{Symbol("net.imagej.ImageJ")}(Ptr{Nothing} @0x0000560b5e6c5298)

julia> ImageJ1()
JavaObject{Symbol("ij.ImageJ")}(Ptr{Nothing} @0x0000560b5e6c52a8)
```

Otherwise, we have to use the weird Tuple syntax:

```
julia> using JavaCall
┌ Warning: JavaCall needs the environment variable `JULIA_COPY_STACKS` to be `1` or `yes`.
│ Calling the JVM may result in undefined behavior.
└ @ JavaCall ~/.julia/dev/JavaCall/src/JavaCall.jl:42

julia> JavaCall.addClassPath.(["jars/*","jars/bio-formats/*","jars/linux64/*","plugins/*"]); JavaCall.init()

julia> ImageJ2 = @jimport net.imagej.ImageJ
JavaObject{Symbol("net.imagej.ImageJ")}

julia> ImageJ1 = @jimport ij.ImageJ
JavaObject{Symbol("ij.ImageJ")}

julia> ImageJ2((),)
JavaObject{Symbol("net.imagej.ImageJ")}(Ptr{Nothing} @0x00005600d46bf0d8)

julia> ImageJ1((),)
JavaObject{Symbol("ij.ImageJ")}(Ptr{Nothing} @0x00005600d46bf0e8)
```