### PR TITLE
adding readme to point to JProxy file history

### DIFF
--- a/JProxies/README.md
+++ b/JProxies/README.md
@@ -1,0 +1,4 @@
+The JProxies code was originally written by [Bill Burdick](https://github.com/zot). The file history can be seen at these links:
+
+- [proxy.jl](https://github.com/JuliaInterop/JavaCall.jl/blob/b86ae187a71fe12deb89ed316c6cd03be9dc562c/src/proxy.jl)
+- [gen.jl](https://github.com/JuliaInterop/JavaCall.jl/blob/b86ae187a71fe12deb89ed316c6cd03be9dc562c/src/gen.jl)


### PR DESCRIPTION
I made a small readme with links to the original files for history.