### PR TITLE
Raw JNI arrays

### DIFF
--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -7,7 +7,7 @@ module JavaCall
     Base.Experimental.@optlevel 1
 end
 
-export JavaObject, JavaMetaClass, JNIArray,
+export JavaObject, JavaMetaClass, JNIVector,
        jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble, jvoid,
        JObject, JClass, JMethod, JConstructor, JField, JString,
        JavaRef, JavaLocalRef, JavaGlobalRef, JavaNullRef,

--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -7,7 +7,7 @@ module JavaCall
     Base.Experimental.@optlevel 1
 end
 
-export JavaObject, JavaMetaClass,
+export JavaObject, JavaMetaClass, JNIArray,
        jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble, jvoid,
        JObject, JClass, JMethod, JConstructor, JField, JString,
        JavaRef, JavaLocalRef, JavaGlobalRef, JavaNullRef,

--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -39,6 +39,7 @@ include("jvm.jl")
 include("core.jl")
 include("convert.jl")
 include("reflect.jl")
+include("jniarray.jl")
 
 Base.@deprecate_binding jnifunc JavaCall.JNI.jniref[]
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -247,6 +247,38 @@ true if the passed object is null else false
 """
 isnull(obj::JavaMetaClass) = Ptr(obj) == C_NULL
 
+macro checknull(expr, msg="")
+    if expr isa Expr && expr.head == :call
+        jnifun = "$(expr.args[1])"
+        quote
+            local ptr = $(esc(expr))
+            if isnull(ptr) && geterror() === nothing
+                throw(JavaCallError("JavaCall."*$jnifun*": "*$(esc(msg))))
+            end
+            ptr
+        end
+    else
+        quote
+            local ptr = $(esc(expr))
+            if isnull(ptr) && geterror() === nothing
+                throw(JavaCallError($(esc(msg))))
+            end
+            ptr
+        end
+    end
+end
+
+function checknull(ptr, msg="Unexpected null pointer from Java Native Interface", jnifun=nothing)
+    if isnull(ptr) && geterror() === nothing
+        if jnifun === nothing
+            throw(JavaCallError(msg))
+        else
+            throw(JavaCallError("JavaCall.JNI.$jnifun: $msg"))
+        end
+    end
+    ptr
+end
+
 const JClass = JavaObject{Symbol("java.lang.Class")}
 const JObject = JavaObject{Symbol("java.lang.Object")}
 const JMethod = JavaObject{Symbol("java.lang.reflect.Method")}
@@ -259,12 +291,8 @@ const JString = JavaObject{Symbol("java.lang.String")}
 #JavaObject(ptr::Ptr{Nothing}) = ptr == C_NULL ? JavaObject(ptr) : JavaObject{Symbol(getclassname(getclass(ptr)))}(ptr)
 
 function JString(str::AbstractString)
-    jstring = JNI.NewStringUTF(String(str))
-    if jstring == C_NULL
-        geterror()
-    else
-        return JString(jstring)
-    end
+    jstring = @checknull JNI.NewStringUTF(String(str))
+    return JString(jstring)
 end
 
 # jvalue(v::Integer) = int64(v) << (64-8*sizeof(v))
@@ -327,118 +355,129 @@ isarray(juliaclass::String) = endswith(juliaclass, "[]")
 
 function jnew(T::Symbol, argtypes::Tuple = () , args...)
     assertroottask_or_goodenv() && assertloaded()
-    sig = method_signature(Nothing, argtypes...)
-    jmethodId = JNI.GetMethodID(Ptr(metaclass(T)), String("<init>"), sig)
-    if jmethodId == C_NULL
-        throw(JavaCallError("No constructor for $T with signature $sig"))
-    end
-    return  _jcall(metaclass(T), jmethodId, JavaObject{T}, argtypes, args...; callmethod=JNI.NewObjectA)
+    jmethodId = get_method_id(JNI.GetMethodID, T, "<init>", Nothing, argtypes)
+    return _jcall(metaclass(T), jmethodId, JavaObject{T}, argtypes, args...; callmethod=JNI.NewObjectA)
 end
 
 _jcallable(typ::Type{JavaObject{T}}) where T = metaclass(T)
-_jcallable(obj::JavaObject) = obj
+function _jcallable(obj::JavaObject)
+    isnull(obj) && throw(JavaCallError("Attempt to call method on Java NULL"))
+    obj
+end
 
-# Call static methods
 function jcall(ref, method::AbstractString, rettype::Type, argtypes::Tuple = (), args...)
     assertroottask_or_goodenv() && assertloaded()
     jmethodId = get_method_id(ref, method, rettype, argtypes)
-    jmethodId==C_NULL && geterror(true)
     _jcall(_jcallable(ref), jmethodId, rettype, argtypes, args...)
 end
 
-function get_method_id(typ::Type{JavaObject{T}}, method::AbstractString, rettype::Type, argtypes::Tuple) where T
+function jcall(ref, method::JMethod, args...)
+    assertroottask_or_goodenv() && assertloaded()
+    jmethodId = get_method_id(method)
+    rettype = jimport(getreturntype(method))
+    argtypes = Tuple(jimport.(getparametertypes(method)))
+    _jcall(_jcallable(ref), jmethodId, rettype, argtypes, args...)
+end
+
+function get_method_id(jnifun::Function, obj, method::AbstractString, rettype::Type, argtypes::Tuple)
     sig = method_signature(rettype, argtypes...)
-    JNI.GetStaticMethodID(Ptr(metaclass(T)), String(method), sig)
+    ptr = Ptr(metaclass(obj))
+    @checknull jnifun(ptr, String(method), sig) "Problem getting method id for $obj.$method with signature $sig"
+end
+
+function get_method_id(typ::Type{JavaObject{T}}, method::AbstractString, rettype::Type, argtypes::Tuple) where T
+    get_method_id(JNI.GetStaticMethodID, T, method, rettype, argtypes)
 end
 
 function get_method_id(obj::JavaObject, method::AbstractString, rettype::Type, argtypes::Tuple)
-    sig = method_signature(rettype, argtypes...)
-    JNI.GetMethodID(Ptr(metaclass(obj)), String(method), sig)
+    get_method_id(JNI.GetMethodID, obj, method, rettype, argtypes)
 end
 
-function get_method_id(obj::JavaObject, method::JMethod)
-    sig = method_signature(rettype, argtypes...)
-    JNI.FromReflectedMethod(method)
-end
-
-function jcall(ref, method::JMethod, args...) where T
-    jmethodId = JNI.FromReflectedMethod(method)
-    rettype = jimport(getreturntype(method))
-    argtypes = Tuple(jimport.(getparametertypes(method)))
-    jmethodId==C_NULL && geterror(true)
-    _jcall(metaclass(T), jmethodId, rettype, argtypes, args...)
-end
-
-function jcall(obj::JavaObject, method::JMethod, args... )
-    assertroottask_or_goodenv() && assertloaded()
-    isnull(obj) && throw(JavaCallError("Attempt to call method on Java NULL"))
-    jmethodId = JNI.FromReflectedMethod(method)
-    rettype = jimport(getreturntype(method))
-    argtypes = Tuple(jimport.(getparametertypes(method)))
-    jmethodId==C_NULL && geterror(true)
-    _jcall(obj, jmethodId, rettype,  argtypes, args...)
-end
+get_method_id(method::JMethod) = @checknull JNI.FromReflectedMethod(method)
 
 # JMethod invoke
 (m::JMethod)(obj, args...) = jcall(obj, m, args...)
 
 
+"""
+    jfield(ref, field, [fieldType])
+
+Get a pointer to a field of of a Java class or object.
+* `ref` could be a JavaObject{T} type or a JavaObject
+* `field` can be an AbstractString or JField
+* `fieldType` is a Type
+"""
 function jfield(ref, field, fieldType)
     assertroottask_or_goodenv() && assertloaded()
     jfieldID = get_field_id(ref, field, fieldType)
-    jfieldID==C_NULL && geterror(true)
+    _jfield(_jcallable(ref), jfieldID, fieldType)
+end
+
+function jfield(ref, field)
+    assertroottask_or_goodenv() && assertloaded()
+    fieldType = jimport(gettype(field))
+    jfieldID = get_field_id(ref, field, fieldType)
+    _jfield(_jcallable(ref), jfieldID, fieldType)
+end
+
+function jfield(ref, field::AbstractString)
+    assertroottask_or_goodenv() && assertloaded()
+    field = listfields(ref, field)[]
+    fieldType = jimport(gettype(field))
+    jfieldID = get_field_id(ref, field, fieldType)
     _jfield(_jcallable(ref), jfieldID, fieldType)
 end
 
 function get_field_id(typ::Type{JavaObject{T}}, field::AbstractString, fieldType::Type) where T
-    JNI.GetStaticFieldID(Ptr(metaclass(T)), String(field), signature(fieldType))
+    @checknull JNI.GetStaticFieldID(Ptr(metaclass(T)), String(field), signature(fieldType))
 end
 
 function get_field_id(obj::Type{JavaObject{T}}, field::JField) where T
     fieldType = jimport(gettype(field))
-    JNI.FromReflectedField(field)
+    @checknull JNI.FromReflectedField(field)
 end
 
 function get_field_id(obj::JavaObject, field::AbstractString, fieldType::Type)
-    JNI.GetFieldID(Ptr(metaclass(obj)), String(field), signature(fieldType))
+    @checknull JNI.GetFieldID(Ptr(metaclass(obj)), String(field), signature(fieldType))
 end
 
-function get_field_id(obj::JavaObject, field::JField)
-    fieldType = jimport(gettype(field))
-    JNI.FromReflectedField(field)
+function get_field_id(obj::JavaObject, field::JField, fieldType::Type)
+    @checknull JNI.FromReflectedField(field)
 end
 
 # JField invoke
 (f::JField)(obj) = jfield(obj, f)
 
-for (x, name) in [(:Type,             "Object"),
-                  (:(Type{jboolean}), "Boolean"),
-                  (:(Type{jchar}),    "Char"   ),
-                  (:(Type{jbyte}),    "Byte"   ),
-                  (:(Type{jshort}),   "Short"  ),
-                  (:(Type{jint}),     "Int"    ),
-                  (:(Type{jlong}),    "Long"   ),
-                  (:(Type{jfloat}),   "Float"  ),
-                  (:(Type{jdouble}),  "Double" ),
-                  (:(Type{jvoid}),    "Void"   )]
-    for (t, cstr, fstr) in [(:JavaObject,    "Call$(name)MethodA",      "Get$(name)Field"),
-                            (:JavaMetaClass, "CallStatic$(name)MethodA", "GetStatic$(name)Field")]
-        callmethod = :(JNI.$(Symbol(cstr)))
-        fieldmethod = :(JNI.$(Symbol(fstr)))
+for (x, name) in [(:(<:Any),  :Object),
+                  (:jboolean, :Boolean),
+                  (:jchar,    :Char   ),
+                  (:jbyte,    :Byte   ),
+                  (:jshort,   :Short  ),
+                  (:jint,     :Int    ),
+                  (:jlong,    :Long   ),
+                  (:jfloat,   :Float  ),
+                  (:jdouble,  :Double ),
+                  (:jvoid,    :Void   )]
+    for (t, callprefix, getprefix) in [
+        (:JavaObject,    :Call, :Get ),
+        (:JavaMetaClass, :CallStatic, :GetStatic )
+    ]
+        callmethod = :(JNI.$(Symbol(callprefix, name, :MethodA)))
+        fieldmethod = :(JNI.$(Symbol(getprefix, name, :Field)))
         m = quote
-            function _jfield(obj::T, jfieldID::Ptr{Nothing}, fieldType::$x) where T <: $t
+            function _jfield(obj::T, jfieldID::Ptr{Nothing}, fieldType::Type{$x}) where T <: $t
                 result = $fieldmethod(Ptr(obj), jfieldID)
-                result==C_NULL && geterror()
+                geterror()
                 return convert_result(fieldType, result)
             end
-            function _jcall(obj::T, jmethodId::Ptr{Nothing}, rettype::$x,
+            function _jcall(obj::T, jmethodId::Ptr{Nothing}, rettype::Type{$x},
                             argtypes::Tuple, args...; callmethod=$callmethod) where T <: $t
                 savedArgs, convertedArgs = convert_args(argtypes, args...)
                 GC.@preserve savedArgs begin
                     result = callmethod(Ptr(obj), jmethodId, Array{JNI.jvalue}(jvalue.(convertedArgs)))
                 end
                 cleanup_arg.(convertedArgs)
-                result==C_NULL && geterror()
+                geterror()
                 return convert_result(rettype, result)
             end
         end
@@ -453,8 +492,7 @@ global const _jmc_cache = [ Dict{Symbol, JavaMetaClass}() ]
 
 function _metaclass(class::Symbol)
     jclass=javaclassname(class)
-    jclassptr = JNI.FindClass(jclass)
-    jclassptr == C_NULL && throw(JavaCallError("Class Not Found $jclass"))
+    jclassptr = @checknull JNI.FindClass(jclass)
     return JavaMetaClass(class, jclassptr)
 end
 
@@ -474,28 +512,37 @@ javaclassname(class::Symbol) = replace(string(class), "."=>"/")
 javaclassname(class::AbstractString) = replace(class, "."=>"/")
 javaclassname(::Type{T}) where T <: AbstractVector = JavaCall.signature(T)
 
-function geterror(allow=false)
+function _notnull_assert(ptr)
+    isnull(ptr) && throw(JavaCallError("Java Exception thrown, but no details could be retrieved from the JVM"))
+end
+
+function get_exception_string(jthrow)
+    jthrowable = JNI.FindClass("java/lang/Throwable")
+    _notnull_assert(jthrowable)
+
+    tostring_method = JNI.GetMethodID(jthrowable, "toString", "()Ljava/lang/String;")
+    _notnull_assert(tostring_method)
+
+    res = JNI.CallObjectMethodA(jthrow, tostring_method, Int[])
+    _notnull_assert(res)
+
+    return unsafe_string(JString(res))
+end
+
+function geterror()
     isexception = JNI.ExceptionCheck()
 
     if isexception == JNI_TRUE
         jthrow = JNI.ExceptionOccurred()
-        jthrow==C_NULL && throw(JavaCallError("Java Exception thrown, but no details could be retrieved from the JVM"))
-        JNI.ExceptionDescribe() #Print java stackstrace to stdout
-        JNI.ExceptionClear()
-        jclass = JNI.FindClass("java/lang/Throwable")
-        jclass==C_NULL && throw(JavaCallError("Java Exception thrown, but no details could be retrieved from the JVM"))
-        jmethodId=JNI.GetMethodID(jclass, "toString", "()Ljava/lang/String;")
-        jmethodId==C_NULL && throw(JavaCallError("Java Exception thrown, but no details could be retrieved from the JVM"))
-        res = JNI.CallObjectMethodA(jthrow, jmethodId, Int[])
-        res==C_NULL && throw(JavaCallError("Java Exception thrown, but no details could be retrieved from the JVM"))
-        msg = unsafe_string(JString(res))
-        JNI.DeleteLocalRef(jthrow)
-        throw(JavaCallError(string("Error calling Java: ",msg)))
-    else
-        if allow==false
-            return #No exception pending, legitimate NULL returned from Java
-        else
-            throw(JavaCallError("Null from Java. Not known how"))
+        _notnull_assert(jthrow)
+        try
+            JNI.ExceptionDescribe() #Print java stackstrace to stdout
+
+            msg = get_exception_string(jthrow)
+            throw(JavaCallError(string("Error calling Java: ", msg)))
+        finally
+            JNI.ExceptionClear()
+            JNI.DeleteLocalRef(jthrow)
         end
     end
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -332,166 +332,128 @@ function jnew(T::Symbol, argtypes::Tuple = () , args...)
     if jmethodId == C_NULL
         throw(JavaCallError("No constructor for $T with signature $sig"))
     end
-    return  _jcall(metaclass(T), jmethodId, JNI.NewObjectA, JavaObject{T}, argtypes, args...)
+    return  _jnicall(metaclass(T), jmethodId, JNI.NewObjectA, JavaObject{T}, argtypes, args...)
 end
+
+_jcallable(typ::Type{JavaObject{T}}) where T = metaclass(T)
+_jcallable(obj::JavaObject) = obj
 
 # Call static methods
-function jcall(typ::Type{JavaObject{T}}, method::AbstractString, rettype::Type, argtypes::Tuple = (),
-               args... ) where T
+function jcall(ref, method::AbstractString, rettype::Type, argtypes::Tuple = (), args...)
     assertroottask_or_goodenv() && assertloaded()
-    sig = method_signature(rettype, argtypes...)
-    jmethodId = JNI.GetStaticMethodID(Ptr(metaclass(T)), String(method), sig)
+    jmethodId = get_method_id(ref, method, rettype, argtypes)
     jmethodId==C_NULL && geterror(true)
-    _jcall(metaclass(T), jmethodId, C_NULL, rettype, argtypes, args...)
+    _jcall(_jcallable(ref), jmethodId, rettype, argtypes, args...)
 end
 
-function jcall(typ::Type{JavaObject{T}}, method::JMethod, args...) where T
-    assertroottask_or_goodenv() && assertloaded()
+function get_method_id(typ::Type{JavaObject{T}}, method::AbstractString, rettype::Type, argtypes::Tuple) where T
+    sig = method_signature(rettype, argtypes...)
+    JNI.GetStaticMethodID(Ptr(metaclass(T)), String(method), sig)
+end
+
+function get_method_id(obj::JavaObject, method::AbstractString, rettype::Type, argtypes::Tuple)
+    sig = method_signature(rettype, argtypes...)
+    JNI.GetMethodID(Ptr(metaclass(obj)), String(method), sig)
+end
+
+function get_method_id(obj::JavaObject, method::JMethod)
+    sig = method_signature(rettype, argtypes...)
+    JNI.FromReflectedMethod(method)
+end
+
+function jcall(ref, method::JMethod, args...) where T
     jmethodId = JNI.FromReflectedMethod(method)
     rettype = jimport(getreturntype(method))
     argtypes = Tuple(jimport.(getparametertypes(method)))
     jmethodId==C_NULL && geterror(true)
-    _jcall(metaclass(T), jmethodId, C_NULL, rettype, argtypes, args...)
-end
-
-# Call instance methods
-function jcall(obj::JavaObject, method::AbstractString, rettype::Type, argtypes::Tuple = (), args... )
-    assertroottask_or_goodenv() && assertloaded()
-    sig = method_signature(rettype, argtypes...)
-    jmethodId = JNI.GetMethodID(Ptr(metaclass(obj)), String(method), sig)
-    jmethodId==C_NULL && geterror(true)
-    _jcall(obj, jmethodId, C_NULL, rettype,  argtypes, args...)
+    _jcall(metaclass(T), jmethodId, rettype, argtypes, args...)
 end
 
 function jcall(obj::JavaObject, method::JMethod, args... )
     assertroottask_or_goodenv() && assertloaded()
+    isnull(obj) && throw(JavaCallError("Attempt to call method on Java NULL"))
     jmethodId = JNI.FromReflectedMethod(method)
     rettype = jimport(getreturntype(method))
     argtypes = Tuple(jimport.(getparametertypes(method)))
     jmethodId==C_NULL && geterror(true)
-    _jcall(obj, jmethodId, C_NULL, rettype,  argtypes, args...)
+    _jcall(obj, jmethodId, rettype,  argtypes, args...)
 end
 
 # JMethod invoke
 (m::JMethod)(obj, args...) = jcall(obj, m, args...)
 
 
-function jfield(typ::Type{JavaObject{T}}, field::AbstractString, fieldType::Type) where T
+function jfield(ref, field, fieldType)
     assertroottask_or_goodenv() && assertloaded()
-    jfieldID  = JNI.GetStaticFieldID(Ptr(metaclass(T)), String(field), signature(fieldType))
+    jfieldID = get_field_id(ref, field, fieldType)
     jfieldID==C_NULL && geterror(true)
-    _jfield(metaclass(T), jfieldID, fieldType)
+    _jfield(_jcallable(ref), jfieldID, fieldType)
 end
 
-function jfield(obj::Type{JavaObject{T}}, field::JField) where T
-    assertroottask_or_goodenv() && assertloaded()
+function get_field_id(typ::Type{JavaObject{T}}, field::AbstractString, fieldType::Type) where T
+    JNI.GetStaticFieldID(Ptr(metaclass(T)), String(field), signature(fieldType))
+end
+
+function get_field_id(obj::Type{JavaObject{T}}, field::JField) where T
     fieldType = jimport(gettype(field))
-    jfieldID = JNI.FromReflectedField(field)
-    jfieldID==C_NULL && geterror(true)
-    _jfield(metaclass(T), jfieldID, fieldType)
+    JNI.FromReflectedField(field)
 end
 
-function jfield(obj::JavaObject, field::AbstractString, fieldType::Type)
-    assertroottask_or_goodenv() && assertloaded()
-    jfieldID  = JNI.GetFieldID(Ptr(metaclass(obj)), String(field), signature(fieldType))
-    jfieldID==C_NULL && geterror(true)
-    _jfield(obj, jfieldID, fieldType)
+function get_field_id(obj::JavaObject, field::AbstractString, fieldType::Type)
+    JNI.GetFieldID(Ptr(metaclass(obj)), String(field), signature(fieldType))
 end
 
-function jfield(obj::JavaObject, field::JField)
-    assertroottask_or_goodenv() && assertloaded()
+function get_field_id(obj::JavaObject, field::JField)
     fieldType = jimport(gettype(field))
-    jfieldID = JNI.FromReflectedField(field)
-    jfieldID==C_NULL && geterror(true)
-    _jfield(obj, jfieldID, fieldType)
+    JNI.FromReflectedField(field)
 end
 
 # JField invoke
 (f::JField)(obj) = jfield(obj, f)
 
-for (x, y, z) in [(:jboolean, :(JNI.GetBooleanField), :(JNI.GetStaticBooleanField)),
-                  (:jchar,    :(JNI.GetCharField),    :(JNI.GetStaticCharField))   ,
-                  (:jbyte,    :(JNI.GetByteField),    :(JNI.GetStaticBypeField))   ,
-                  (:jshort,   :(JNI.GetShortField),   :(JNI.GetStaticShortField))  ,
-                  (:jint,     :(JNI.GetIntField),     :(JNI.GetStaticIntField))    ,
-                  (:jlong,    :(JNI.GetLongField),    :(JNI.GetStaticLongField))   ,
-                  (:jfloat,   :(JNI.GetFloatField),   :(JNI.GetStaticFloatField))  ,
-                  (:jdouble,  :(JNI.GetDoubleField),  :(JNI.GetStaticDoubleField)) ]
-
-    m = quote
-        function _jfield(obj, jfieldID::Ptr{Nothing}, fieldType::Type{$(x)})
-            callmethod = ifelse( typeof(obj)<:JavaObject, $y , $z )
-            result = callmethod(Ptr(obj), jfieldID)
-            result==C_NULL && geterror()
-            return convert_result(fieldType, result)
-        end
-    end
-    eval(m)
-end
-
 function _jfield(obj, jfieldID::Ptr{Nothing}, fieldType::Type)
-    callmethod = ifelse( typeof(obj)<:JavaObject, JNI.GetObjectField , JNI.GetStaticObjectField )
-    result = callmethod(Ptr(obj), jfieldID)
+    result = _jnifield(obj, jfieldID, fieldType)
     result==C_NULL && geterror()
     return convert_result(fieldType, result)
 end
 
-#Generate these methods to satisfy ccall's compile time constant requirement
-#_jcall for primitive and Nothing return types
-for (x, y, z) in [(:jboolean, :(JNI.CallBooleanMethodA), :(JNI.CallStaticBooleanMethodA)),
-                  (:jchar,    :(JNI.CallCharMethodA),    :(JNI.CallStaticCharMethodA))   ,
-                  (:jbyte,    :(JNI.CallByteMethodA),    :(JNI.CallStaticByteMethodA))   ,
-                  (:jshort,   :(JNI.CallShortMethodA),   :(JNI.CallStaticShortMethodA))  ,
-                  (:jint,     :(JNI.CallIntMethodA),     :(JNI.CallStaticIntMethodA))    ,
-                  (:jlong,    :(JNI.CallLongMethodA),    :(JNI.CallStaticLongMethodA))   ,
-                  (:jfloat,   :(JNI.CallFloatMethodA),   :(JNI.CallStaticFloatMethodA))  ,
-                  (:jdouble,  :(JNI.CallDoubleMethodA),  :(JNI.CallStaticDoubleMethodA)) ,
-                  (:jvoid,    :(JNI.CallVoidMethodA),    :(JNI.CallStaticVoidMethodA))   ]
-    m = quote
-        function _jcall(obj, jmethodId::Ptr{Nothing}, callmethod::Ptr{Nothing}, rettype::Type{$(x)},
-                        argtypes::Tuple, args...)
-            if callmethod == C_NULL #!
-                callmethod = ifelse( typeof(obj)<:JavaObject, $y , $z )
-            end
-            @assert callmethod != C_NULL
-            @assert jmethodId != C_NULL
-            isnull(obj) && throw(JavaCallError("Attempt to call method on Java NULL"))
-            savedArgs, convertedArgs = convert_args(argtypes, args...)
-            GC.@preserve savedArgs begin
-                result = callmethod(Ptr(obj), jmethodId, Array{JNI.jvalue}(jvalue.(convertedArgs)))
-            end
-            deleteref.(filter(x->isa(x,JavaObject),convertedArgs))
-            result==C_NULL && geterror()
-            result == nothing && (return)
-            return convert_result(rettype, result)
-        end
-    end
-    eval(m)
-end
-
-#_jcall for Object return types
-#obj -- receiver - Class pointer or object prointer
-#jmethodId -- Java method ID
-#callmethod -- the C method pointer to call
-function _jcall(obj, jmethodId::Ptr{Nothing}, callmethod::Union{Function,Ptr{Nothing}}, rettype::Type, argtypes::Tuple,
-                args...)
-    if callmethod == C_NULL
-        callmethod = ifelse(typeof(obj)<:JavaObject,
-                            JNI.CallObjectMethodA  ,
-                            JNI.CallStaticObjectMethodA)
-    end
-    @assert callmethod != C_NULL
-    @assert jmethodId != C_NULL
-    isnull(obj) && error("Attempt to call method on Java NULL")
+function _jcall(obj, jmethodId, callmethod, rettype, argtypes, args...)
     savedArgs, convertedArgs = convert_args(argtypes, args...)
     GC.@preserve savedArgs begin
-        result = callmethod(Ptr(obj), jmethodId, Array{JNI.jvalue}(jvalue.(convertedArgs)))
+        result = _jnicall(obj, jmethodId, rettype, argtypes, jvalue.(convertedArgs))
     end
     deleteref.(filter(x->isa(x,JavaObject),convertedArgs))
     result==C_NULL && geterror()
     return convert_result(rettype, result)
 end
 
+#Generate these methods to satisfy ccall's compile time constant requirement
+for (x, name) in [(:Type,             "Object"),
+                  (:(Type{jboolean}), "Boolean"),
+                  (:(Type{jchar}),    "Char"   ),
+                  (:(Type{jbyte}),    "Byte"   ),
+                  (:(Type{jshort}),   "Short"  ),
+                  (:(Type{jint}),     "Int"    ),
+                  (:(Type{jlong}),    "Long"   ),
+                  (:(Type{jfloat}),   "Float"  ),
+                  (:(Type{jdouble}),  "Double" ),
+                  (:(Type{jvoid}),    "Void"   )]
+    for (t, cstr, fstr) in [(:JavaObject,    "Call$(name)MethodA",      "Get$(name)Field"),
+                            (:JavaMetaClass, "CallStatic$(name)MethodA", "GetStatic$(name)Field")]
+        callmethod = :(JNI.$(Symbol(cstr)))
+        fieldmethod = :(JNI.$(Symbol(fstr)))
+        m = quote
+            function _jnicall(obj::T, jmethodId::Ptr{Nothing}, rettype::$x,
+                            argtypes::Tuple, args) where T <: $t
+                $callmethod(Ptr(obj), jmethodId, Array{JNI.jvalue}(args))
+            end
+            function _jnifield(obj::T, jfieldID::Ptr{Nothing}, fieldType::$x) where T <: $t
+                $fieldmethod(Ptr(obj), jfieldID)
+            end
+        end
+        eval(m)
+    end
+end
 
 global const _jmc_cache = [ Dict{Symbol, JavaMetaClass}() ]
 
@@ -557,33 +519,17 @@ function method_signature(rettype, argtypes...)
     return String(take!(s))
 end
 
-
 #get the JNI signature string for a given type
-function signature(arg::Type)
-    if arg === jboolean
-        return "Z"
-    elseif arg === jbyte
-        return "B"
-    elseif arg === jchar
-        return "C"
-    elseif arg === jshort
-        return "S"
-    elseif arg === jint
-        return "I"
-    elseif arg === jlong
-        return "J"
-    elseif arg === jfloat
-        return "F"
-    elseif arg === jdouble
-        return "D"
-    elseif arg === jvoid
-        return "V"
-    elseif arg <: Array
-        dims = "[" ^ ndims(arg)
-        return string(dims, signature(eltype(arg)))
-    end
-end
-
+signature(::Type{jboolean}) = "Z"
+signature(::Type{jbyte}) = "B"
+signature(::Type{jchar}) = "C"
+signature(::Type{jshort}) = "S"
+signature(::Type{jint}) = "I"
+signature(::Type{jlong}) = "J"
+signature(::Type{jfloat}) = "F"
+signature(::Type{jdouble}) = "D"
+signature(::Type{jvoid}) = "V"
+signature(::Type{Array{T,N}}) where {T,N} = string("[" ^ N, signature(T))
 signature(arg::Type{JavaObject{T}}) where {T} = string("L", javaclassname(T), ";")
 signature(arg::Type{JavaObject{T}}) where {T <: AbstractVector} = JavaCall.javaclassname(T)
 

--- a/src/jniarray.jl
+++ b/src/jniarray.jl
@@ -23,7 +23,7 @@ Base.setindex!(jarr::JNIArray, args...) = setindex!(jarr.arr, args...)
 Base.size(jarr::JNIArray, args...; kwargs...) = size(jarr.arr, args...; kwargs...)
 
 function deleteref(x::JNIArray{T}) where T
-    if !isnothing(x.arr)
+    if x.arr !== nothing
         release_elements(x)
     end
     deleteref(x.ref)

--- a/src/jniarray.jl
+++ b/src/jniarray.jl
@@ -34,6 +34,14 @@ signature(::Type{JNIArray{T}}) where T = string("[", signature(T))
 jvalue(jarr::JNIArray) = jarr.ref.ptr
 JNIArray{T}(ptr::Ptr{Nothing}) where {T} = JNIArray{T}(JavaLocalRef(ptr))
 
+function convert(::Type{JNIArray{T}}, vec::Vector{T}) where {T}
+    arr = JNIArray{T}(length(vec))
+    arr .= vec
+    return arr
+end
+
+JNIArray(vec::Vector{T}) where {T} = convert(JNIArray{T}, vec)
+
 for primitive in [:jboolean, :jchar, :jbyte, :jshort, :jint, :jlong, :jfloat, :jdouble]
     name = jniname(eval(primitive))
     get_elements = :(JNI.$(Symbol("Get$(name)ArrayElements")))

--- a/src/jniarray.jl
+++ b/src/jniarray.jl
@@ -1,0 +1,26 @@
+jniname(::Type{jboolean}) = "Boolean"
+jniname(::Type{jbyte}) = "Byte"
+jniname(::Type{jchar}) = "Char"
+jniname(::Type{jshort}) = "Short"
+jniname(::Type{jint}) = "Int"
+jniname(::Type{jlong}) = "Long"
+jniname(::Type{jfloat}) = "Float"
+jniname(::Type{jdouble}) = "Double"
+
+
+mutable struct JNIArray{T,N}
+    arr
+end
+signature(::Type{JNIArray{T,N}}) where {T,N} = string("[" ^ N, signature(T))
+
+for primitive in [:jboolean, :jchar, :jbyte, :jshort, :jint, :jlong, :jfloat, :jdouble]
+    name = jniname(eval(primitive))
+    get_elements = :(JNI.$(Symbol("Get$(name)ArrayElements")))
+    m = quote
+        function convert_result(::Type{JNIArray{$primitive, N}}, ptr) where N
+            sz = Int(JNI.GetArrayLength(ptr))
+            JNIArray{$primitive,N}(unsafe_wrap(Array, $get_elements(ptr, UInt8[JNI.JNI_FALSE]), sz))
+        end
+    end
+    eval(m)
+end

--- a/src/jniarray.jl
+++ b/src/jniarray.jl
@@ -8,39 +8,60 @@ jniname(::Type{jfloat}) = "Float"
 jniname(::Type{jdouble}) = "Double"
 
 
-mutable struct JNIArray{T,N}
-    ptr
-    arr::Union{Nothing,Array{T,N}}
+mutable struct JNIArray{T} <: AbstractVector{T}
+    ref::JavaRef
+    arr::Union{Nothing,Vector{T}}
+    function JNIArray{T}(ref) where T
+        j = new{T}(ref, nothing)
+        finalizer(deleteref, j)
+        return j
+    end
 end
 
-JNIArray(ptr) = get_elements!(JNIArray)
-signature(::Type{JNIArray{T,N}}) where {T,N} = string("[" ^ N, signature(T))
-jvalue(jarr::JNIArray) = jarr.ptr
+Base.getindex(jarr::JNIArray, args...) = getindex(jarr.arr, args...)
+Base.setindex!(jarr::JNIArray, args...) = setindex!(jarr.arr, args...)
+Base.size(jarr::JNIArray, args...; kwargs...) = size(jarr.arr, args...; kwargs...)
+
+function deleteref(x::JNIArray{T}) where T
+    if !isnothing(x.arr)
+        release_elements(x)
+    end
+    deleteref(x.ref)
+    x.ref = J_NULL
+end
+
+signature(::Type{JNIArray{T}}) where T = string("[", signature(T))
+jvalue(jarr::JNIArray) = jarr.ref.ptr
+JNIArray{T}(ptr::Ptr{Nothing}) where {T} = JNIArray{T}(JavaLocalRef(ptr))
 
 for primitive in [:jboolean, :jchar, :jbyte, :jshort, :jint, :jlong, :jfloat, :jdouble]
     name = jniname(eval(primitive))
     get_elements = :(JNI.$(Symbol("Get$(name)ArrayElements")))
     release_elements = :(JNI.$(Symbol("Release$(name)ArrayElements")))
+    new_array = :(JNI.$(Symbol("New$(name)Array")))
     m = quote
-        function get_elements!(jarr::JNIArray{$primitive, N}) where N
-            sz = Int(JNI.GetArrayLength(jarr.ptr))
-            jarr.arr = unsafe_wrap(Array, $get_elements(jarr.ptr, Ptr{jboolean}(C_NULL)), sz)
+        function get_elements!(jarr::JNIArray{$primitive})
+            sz = Int(JNI.GetArrayLength(jarr.ref.ptr))
+            jarr.arr = unsafe_wrap(Array, $get_elements(jarr.ref.ptr, Ptr{jboolean}(C_NULL)), sz)
             jarr
         end
-        function convert_result(::Type{JNIArray{$primitive, N}}, ptr) where N
-            get_elements!(JNIArray{$primitive,N}(ptr, nothing))
-        end
-        function convert_arg(argtype::Type{Vector{$primitive}}, arg::JNIArray{$primitive,1}) where N
-            $release_elements(arg.ptr, pointer(arg.arr), jint(0))
+        JNIArray{$primitive}(sz::Int) = get_elements!(JNIArray{$primitive}($new_array(sz)))
+        function release_elements(arg::JNIArray{$primitive})
+            $release_elements(arg.ref.ptr, pointer(arg.arr), jint(0))
             arg.arr = nothing
-            return arg, arg.ptr
         end
-        function convert_arg(argtype::Type{JNIArray{$primitive,1}}, arg::JNIArray{$primitive,1}) where N
-            $release_elements(arg.ptr, pointer(arg.arr), jint(0))
-            arg.arr = nothing
+        function convert_result(::Type{JNIArray{$primitive}}, ptr)
+            get_elements!(JNIArray{$primitive}(ptr))
+        end
+        function convert_arg(argtype::Type{Vector{$primitive}}, arg::JNIArray{$primitive})
+            release_elements(arg)
             return arg, arg
         end
-        function cleanup_arg(jarr::JNIArray{$primitive, N}) where N
+        function convert_arg(argtype::Type{JNIArray{$primitive}}, arg::JNIArray{$primitive})
+            release_elements(arg)
+            return arg, arg
+        end
+        function cleanup_arg(jarr::JNIArray{$primitive})
             get_elements!(jarr)
         end
     end

--- a/src/jniarray.jl
+++ b/src/jniarray.jl
@@ -8,21 +8,21 @@ jniname(::Type{jfloat}) = "Float"
 jniname(::Type{jdouble}) = "Double"
 
 
-mutable struct JNIArray{T} <: AbstractVector{T}
+mutable struct JNIVector{T} <: AbstractVector{T}
     ref::JavaRef
     arr::Union{Nothing,Vector{T}}
-    function JNIArray{T}(ref) where T
+    function JNIVector{T}(ref) where T
         j = new{T}(ref, nothing)
         finalizer(deleteref, j)
         return j
     end
 end
 
-Base.getindex(jarr::JNIArray, args...) = getindex(jarr.arr, args...)
-Base.setindex!(jarr::JNIArray, args...) = setindex!(jarr.arr, args...)
-Base.size(jarr::JNIArray, args...; kwargs...) = size(jarr.arr, args...; kwargs...)
+Base.getindex(jarr::JNIVector, args...) = getindex(jarr.arr, args...)
+Base.setindex!(jarr::JNIVector, args...) = setindex!(jarr.arr, args...)
+Base.size(jarr::JNIVector, args...; kwargs...) = size(jarr.arr, args...; kwargs...)
 
-function deleteref(x::JNIArray{T}) where T
+function deleteref(x::JNIVector{T}) where T
     if x.arr !== nothing
         release_elements(x)
     end
@@ -30,17 +30,17 @@ function deleteref(x::JNIArray{T}) where T
     x.ref = J_NULL
 end
 
-signature(::Type{JNIArray{T}}) where T = string("[", signature(T))
-jvalue(jarr::JNIArray) = jarr.ref.ptr
-JNIArray{T}(ptr::Ptr{Nothing}) where {T} = JNIArray{T}(JavaLocalRef(ptr))
+signature(::Type{JNIVector{T}}) where T = string("[", signature(T))
+jvalue(jarr::JNIVector) = jarr.ref.ptr
+JNIVector{T}(ptr::Ptr{Nothing}) where {T} = JNIVector{T}(JavaLocalRef(ptr))
 
-function convert(::Type{JNIArray{T}}, vec::Vector{T}) where {T}
-    arr = JNIArray{T}(length(vec))
+function convert(::Type{JNIVector{T}}, vec::Vector{T}) where {T}
+    arr = JNIVector{T}(length(vec))
     arr .= vec
     return arr
 end
 
-JNIArray(vec::Vector{T}) where {T} = convert(JNIArray{T}, vec)
+JNIVector(vec::Vector{T}) where {T} = convert(JNIVector{T}, vec)
 
 for primitive in [:jboolean, :jchar, :jbyte, :jshort, :jint, :jlong, :jfloat, :jdouble]
     name = jniname(eval(primitive))
@@ -48,28 +48,28 @@ for primitive in [:jboolean, :jchar, :jbyte, :jshort, :jint, :jlong, :jfloat, :j
     release_elements = :(JNI.$(Symbol("Release$(name)ArrayElements")))
     new_array = :(JNI.$(Symbol("New$(name)Array")))
     m = quote
-        function get_elements!(jarr::JNIArray{$primitive})
+        function get_elements!(jarr::JNIVector{$primitive})
             sz = Int(JNI.GetArrayLength(jarr.ref.ptr))
             jarr.arr = unsafe_wrap(Array, $get_elements(jarr.ref.ptr, Ptr{jboolean}(C_NULL)), sz)
             jarr
         end
-        JNIArray{$primitive}(sz::Int) = get_elements!(JNIArray{$primitive}($new_array(sz)))
-        function release_elements(arg::JNIArray{$primitive})
+        JNIVector{$primitive}(sz::Int) = get_elements!(JNIVector{$primitive}($new_array(sz)))
+        function release_elements(arg::JNIVector{$primitive})
             $release_elements(arg.ref.ptr, pointer(arg.arr), jint(0))
             arg.arr = nothing
         end
-        function convert_result(::Type{JNIArray{$primitive}}, ptr)
-            get_elements!(JNIArray{$primitive}(ptr))
+        function convert_result(::Type{JNIVector{$primitive}}, ptr)
+            get_elements!(JNIVector{$primitive}(ptr))
         end
-        function convert_arg(argtype::Type{Vector{$primitive}}, arg::JNIArray{$primitive})
+        function convert_arg(argtype::Type{Vector{$primitive}}, arg::JNIVector{$primitive})
             release_elements(arg)
             return arg, arg
         end
-        function convert_arg(argtype::Type{JNIArray{$primitive}}, arg::JNIArray{$primitive})
+        function convert_arg(argtype::Type{JNIVector{$primitive}}, arg::JNIVector{$primitive})
             release_elements(arg)
             return arg, arg
         end
-        function cleanup_arg(jarr::JNIArray{$primitive})
+        function cleanup_arg(jarr::JNIVector{$primitive})
             get_elements!(jarr)
         end
     end

--- a/src/jniarray.jl
+++ b/src/jniarray.jl
@@ -9,17 +9,39 @@ jniname(::Type{jdouble}) = "Double"
 
 
 mutable struct JNIArray{T,N}
-    arr
+    ptr
+    arr::Union{Nothing,Array{T,N}}
 end
+
+JNIArray(ptr) = get_elements!(JNIArray)
 signature(::Type{JNIArray{T,N}}) where {T,N} = string("[" ^ N, signature(T))
+jvalue(jarr::JNIArray) = jarr.ptr
 
 for primitive in [:jboolean, :jchar, :jbyte, :jshort, :jint, :jlong, :jfloat, :jdouble]
     name = jniname(eval(primitive))
     get_elements = :(JNI.$(Symbol("Get$(name)ArrayElements")))
+    release_elements = :(JNI.$(Symbol("Release$(name)ArrayElements")))
     m = quote
+        function get_elements!(jarr::JNIArray{$primitive, N}) where N
+            sz = Int(JNI.GetArrayLength(jarr.ptr))
+            jarr.arr = unsafe_wrap(Array, $get_elements(jarr.ptr, Ptr{jboolean}(C_NULL)), sz)
+            jarr
+        end
         function convert_result(::Type{JNIArray{$primitive, N}}, ptr) where N
-            sz = Int(JNI.GetArrayLength(ptr))
-            JNIArray{$primitive,N}(unsafe_wrap(Array, $get_elements(ptr, UInt8[JNI.JNI_FALSE]), sz))
+            get_elements!(JNIArray{$primitive,N}(ptr, nothing))
+        end
+        function convert_arg(argtype::Type{Vector{$primitive}}, arg::JNIArray{$primitive,1}) where N
+            $release_elements(arg.ptr, pointer(arg.arr), jint(0))
+            arg.arr = nothing
+            return arg, arg.ptr
+        end
+        function convert_arg(argtype::Type{JNIArray{$primitive,1}}, arg::JNIArray{$primitive,1}) where N
+            $release_elements(arg.ptr, pointer(arg.arr), jint(0))
+            arg.arr = nothing
+            return arg, arg
+        end
+        function cleanup_arg(jarr::JNIArray{$primitive, N}) where N
+            get_elements!(jarr)
         end
     end
     eval(m)

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -10,6 +10,8 @@ function conventional_name(name::AbstractString)
         return "boolean"
     elseif name == "B"
         return "byte"
+    elseif name == "S"
+        return "short"
     elseif name == "C"
         return "char"
     elseif name == "I"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,7 +96,7 @@ end
 @testset "null_1" begin
     H=@jimport java.util.HashMap
     a=jcall(T, "testNull", H, ())
-    @test_throws ErrorException jcall(a, "toString", JString, ())
+    @test_throws JavaCall.JavaCallError jcall(a, "toString", JString, ())
 
     jlist = @jimport java.util.ArrayList
     @test jcall( jlist(), "add", jboolean, (JObject,), JObject(C_NULL)) === 0x01

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,21 +136,21 @@ end
 @testset "jni_arrays_1" begin
     j_u_arrays = @jimport java.util.Arrays
     arr = jint[10,20,30,40,50,60]
-    jniarr = JNIArray(arr)
+    jniarr = JNIVector(arr)
     @test length(arr) == length(jniarr)
     @test size(arr) == size(jniarr)
     @test all(arr .== jniarr)
-    @test 3 == jcall(j_u_arrays, "binarySearch", jint, (JNIArray{jint}, jint), jniarr, 40)
-    @test "[10, 20, 30, 40, 50, 60]" == jcall(j_u_arrays, "toString", JString, (JavaCall.JNIArray{jint},), jniarr)
+    @test 3 == jcall(j_u_arrays, "binarySearch", jint, (JNIVector{jint}, jint), jniarr, 40)
+    @test "[10, 20, 30, 40, 50, 60]" == jcall(j_u_arrays, "toString", JString, (JavaCall.JNIVector{jint},), jniarr)
 
     JCharBuffer = @jimport(java.nio.CharBuffer)
-    buf = jcall(JCharBuffer, "wrap", JCharBuffer, (JNIArray{jchar},), JNIArray(jchar.(collect("array"))))
+    buf = jcall(JCharBuffer, "wrap", JCharBuffer, (JNIVector{jchar},), JNIVector(jchar.(collect("array"))))
     @test "array" == jcall(buf, "toString", JString, ())
 
-    # Ensure JNIArrays are garbage collected properly
+    # Ensure JNIVectors are garbage collected properly
     for i in 1:100000
-        a = JNIArray(jchar[j == i ? 0 : 1 for j in 1:10000])
-        buf = jcall(JCharBuffer, "wrap", JCharBuffer, (JNIArray{jchar},), a)
+        a = JNIVector(jchar[j == i ? 0 : 1 for j in 1:10000])
+        buf = jcall(JCharBuffer, "wrap", JCharBuffer, (JNIVector{jchar},), a)
     end
 end
 


### PR DESCRIPTION
After the discussion in #134 I've experimented with approaches to exposing more of the JNI array functionality. Here is the draft for one such approach so that we can discuss whether this direction is of interest for JavaCall.

This would be a very lightweight approach to exposing the JNI array functionality where the user can choose to keep a returned array as a pointer and get and set elements directly through an `unsafe_wrap` array.

There are also some parts of JProxies that point in this direction but they are less lightweight with a different interface from the rest of JavaCall. I couldn't get them to do exactly what I want. However, if you think the JProxies approach is a better direction I'd be glad to help to surface this functionality through documentation and/or changes to JProxies.

My own immediate use for this is in BioformatsLoader where it would allow me to use the pre-allocated versions of the reader and perform the reinterpretation and reshaping of the array simultaneously as the copy from java. In general, I believe it could expand what is possible without java adapters. @mkitti has already done a lot of work in this general direction and may have ideas for alternative approaches.

One alternative to this approach would be to only wrap the array ref without actually getting the elements. This would be simpler, safer, and even more lightweight. "Direct" access to the array from Julia is pretty convenient though.

Here is an example of how the proposed functionality can be used:

```julia
julia> const JArr = @jimport java.util.Arrays
JavaObject{Symbol("java.util.Arrays")}

julia> arr = JavaCall.JNIArray{jint}(10)
10-element JavaCall.JNIArray{Int32}:
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0

julia> show(arr .= 1:10)
Int32[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
julia> jcall(JArr, "toString", JString, (JavaCall.JNIArray{jint},), arr)
"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"

julia> jcall(JArr, "fill", jvoid, (JavaCall.JNIArray{jint},jint), arr, 5)

julia> show(arr)
Int32[5, 5, 5, 5, 5, 5, 5, 5, 5, 5]
```

I'm sorry if the diff is a bit noisy, I tried to consolidate some things to make it easier for the "raw" arrays to plug in. In the process, I found that the "Attempt to call method on Java NULL" error is sometimes thrown as an `ErrorException` that should probably be fixed independent of whether this gets merged in some form.