### PR TITLE
Add support for short to conventional_name

### DIFF
--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -10,6 +10,8 @@ function conventional_name(name::AbstractString)
         return "boolean"
     elseif name == "B"
         return "byte"
+    elseif name == "S"
+        return "short"
     elseif name == "C"
         return "char"
     elseif name == "I"


### PR DESCRIPTION
While working in a university project we stumbled upon this bug.

Co-authored-by: João David <joaodavid@tecnico.ulisboa.pt>