### PR TITLE
Consolidate jcall to enable extension of JVM types

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -414,11 +414,11 @@ for (x, name) in [(:Type,             "Object"),
                   (:(Type{jdouble}),  "Double" ),
                   (:(Type{jvoid}),    "Void"   )]
     for (t, callprefix, getprefix) in [
-        (:JavaObject,    :(JNI.Call), :(JNI.Get) ),
-        (:JavaMetaClass, :(JNI.CallStatic), :(JNI.GetStatic) )
+        (:JavaObject,    :Call, :Get ),
+        (:JavaMetaClass, :CallStatic, :GetStatic )
     ]
-        callmethod = Symbol(callprefix, name, :MethodA)
-        fieldmethod = Symbol(getprefix, name, :Field)
+        callmethod = :(JNI.$(Symbol(callprefix, name, :MethodA)))
+        fieldmethod = :(JNI.$(Symbol(getprefix, name, :Field)))
         m = quote
             function _jfield(obj::T, jfieldID::Ptr{Nothing}, fieldType::$x) where T <: $t
                 result = $fieldmethod(Ptr(obj), jfieldID)

--- a/src/core.jl
+++ b/src/core.jl
@@ -432,16 +432,16 @@ end
 # JField invoke
 (f::JField)(obj) = jfield(obj, f)
 
-for (x, name) in [(:Type,             "Object"),
-                  (:(Type{jboolean}), "Boolean"),
-                  (:(Type{jchar}),    "Char"   ),
-                  (:(Type{jbyte}),    "Byte"   ),
-                  (:(Type{jshort}),   "Short"  ),
-                  (:(Type{jint}),     "Int"    ),
-                  (:(Type{jlong}),    "Long"   ),
-                  (:(Type{jfloat}),   "Float"  ),
-                  (:(Type{jdouble}),  "Double" ),
-                  (:(Type{jvoid}),    "Void"   )]
+for (x, name) in [(:(<:Any),  :Object),
+                  (:jboolean, :Boolean),
+                  (:jchar,    :Char   ),
+                  (:jbyte,    :Byte   ),
+                  (:jshort,   :Short  ),
+                  (:jint,     :Int    ),
+                  (:jlong,    :Long   ),
+                  (:jfloat,   :Float  ),
+                  (:jdouble,  :Double ),
+                  (:jvoid,    :Void   )]
     for (t, callprefix, getprefix) in [
         (:JavaObject,    :Call, :Get ),
         (:JavaMetaClass, :CallStatic, :GetStatic )
@@ -449,12 +449,12 @@ for (x, name) in [(:Type,             "Object"),
         callmethod = :(JNI.$(Symbol(callprefix, name, :MethodA)))
         fieldmethod = :(JNI.$(Symbol(getprefix, name, :Field)))
         m = quote
-            function _jfield(obj::T, jfieldID::Ptr{Nothing}, fieldType::$x) where T <: $t
+            function _jfield(obj::T, jfieldID::Ptr{Nothing}, fieldType::Type{$x}) where T <: $t
                 result = $fieldmethod(Ptr(obj), jfieldID)
                 geterror()
                 return convert_result(fieldType, result)
             end
-            function _jcall(obj::T, jmethodId::Ptr{Nothing}, rettype::$x,
+            function _jcall(obj::T, jmethodId::Ptr{Nothing}, rettype::Type{$x},
                             argtypes::Tuple, args...; callmethod=$callmethod) where T <: $t
                 savedArgs, convertedArgs = convert_args(argtypes, args...)
                 GC.@preserve savedArgs begin

--- a/src/core.jl
+++ b/src/core.jl
@@ -324,7 +324,10 @@ isarray(juliaclass::String) = endswith(juliaclass, "[]")
 
 function jnew(T::Symbol, argtypes::Tuple = () , args...)
     assertroottask_or_goodenv() && assertloaded()
-    jmethodId = checknull(get_method_id(JNI.GetMethodID, Ptr(metaclass(T)), "<init>", Nothing, argtypes))
+    jmethodId = checknull(
+         get_method_id(JNI.GetMethodID, Ptr(metaclass(T)), "<init>", Nothing, argtypes),
+         "No constructor for $T with signature $sig"
+    )
     return _jcall(metaclass(T), jmethodId, JavaObject{T}, argtypes, args...; callmethod=JNI.NewObjectA)
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -332,166 +332,128 @@ function jnew(T::Symbol, argtypes::Tuple = () , args...)
     if jmethodId == C_NULL
         throw(JavaCallError("No constructor for $T with signature $sig"))
     end
-    return  _jcall(metaclass(T), jmethodId, JNI.NewObjectA, JavaObject{T}, argtypes, args...)
+    return  _jnicall(metaclass(T), jmethodId, JNI.NewObjectA, JavaObject{T}, argtypes, args...)
 end
+
+_jcallable(typ::Type{JavaObject{T}}) where T = metaclass(T)
+_jcallable(obj::JavaObject) = obj
 
 # Call static methods
-function jcall(typ::Type{JavaObject{T}}, method::AbstractString, rettype::Type, argtypes::Tuple = (),
-               args... ) where T
+function jcall(ref, method::AbstractString, rettype::Type, argtypes::Tuple = (), args...)
     assertroottask_or_goodenv() && assertloaded()
-    sig = method_signature(rettype, argtypes...)
-    jmethodId = JNI.GetStaticMethodID(Ptr(metaclass(T)), String(method), sig)
+    jmethodId = get_method_id(ref, method, rettype, argtypes)
     jmethodId==C_NULL && geterror(true)
-    _jcall(metaclass(T), jmethodId, C_NULL, rettype, argtypes, args...)
+    _jcall(_jcallable(ref), jmethodId, rettype, argtypes, args...)
 end
 
-function jcall(typ::Type{JavaObject{T}}, method::JMethod, args...) where T
-    assertroottask_or_goodenv() && assertloaded()
+function get_method_id(typ::Type{JavaObject{T}}, method::AbstractString, rettype::Type, argtypes::Tuple) where T
+    sig = method_signature(rettype, argtypes...)
+    JNI.GetStaticMethodID(Ptr(metaclass(T)), String(method), sig)
+end
+
+function get_method_id(obj::JavaObject, method::AbstractString, rettype::Type, argtypes::Tuple)
+    sig = method_signature(rettype, argtypes...)
+    JNI.GetMethodID(Ptr(metaclass(obj)), String(method), sig)
+end
+
+function get_method_id(obj::JavaObject, method::JMethod)
+    sig = method_signature(rettype, argtypes...)
+    JNI.FromReflectedMethod(method)
+end
+
+function jcall(ref, method::JMethod, args...) where T
     jmethodId = JNI.FromReflectedMethod(method)
     rettype = jimport(getreturntype(method))
     argtypes = Tuple(jimport.(getparametertypes(method)))
     jmethodId==C_NULL && geterror(true)
-    _jcall(metaclass(T), jmethodId, C_NULL, rettype, argtypes, args...)
-end
-
-# Call instance methods
-function jcall(obj::JavaObject, method::AbstractString, rettype::Type, argtypes::Tuple = (), args... )
-    assertroottask_or_goodenv() && assertloaded()
-    sig = method_signature(rettype, argtypes...)
-    jmethodId = JNI.GetMethodID(Ptr(metaclass(obj)), String(method), sig)
-    jmethodId==C_NULL && geterror(true)
-    _jcall(obj, jmethodId, C_NULL, rettype,  argtypes, args...)
+    _jcall(metaclass(T), jmethodId, rettype, argtypes, args...)
 end
 
 function jcall(obj::JavaObject, method::JMethod, args... )
     assertroottask_or_goodenv() && assertloaded()
+    isnull(obj) && throw(JavaCallError("Attempt to call method on Java NULL"))
     jmethodId = JNI.FromReflectedMethod(method)
     rettype = jimport(getreturntype(method))
     argtypes = Tuple(jimport.(getparametertypes(method)))
     jmethodId==C_NULL && geterror(true)
-    _jcall(obj, jmethodId, C_NULL, rettype,  argtypes, args...)
+    _jcall(obj, jmethodId, rettype,  argtypes, args...)
 end
 
 # JMethod invoke
 (m::JMethod)(obj, args...) = jcall(obj, m, args...)
 
 
-function jfield(typ::Type{JavaObject{T}}, field::AbstractString, fieldType::Type) where T
+function jfield(ref, field, fieldType)
     assertroottask_or_goodenv() && assertloaded()
-    jfieldID  = JNI.GetStaticFieldID(Ptr(metaclass(T)), String(field), signature(fieldType))
+    jfieldID = get_field_id(ref, field, fieldType)
     jfieldID==C_NULL && geterror(true)
-    _jfield(metaclass(T), jfieldID, fieldType)
+    _jfield(_jcallable(ref), jfieldID, fieldType)
 end
 
-function jfield(obj::Type{JavaObject{T}}, field::JField) where T
-    assertroottask_or_goodenv() && assertloaded()
+function get_field_id(typ::Type{JavaObject{T}}, field::AbstractString, fieldType::Type) where T
+    JNI.GetStaticFieldID(Ptr(metaclass(T)), String(field), signature(fieldType))
+end
+
+function get_field_id(obj::Type{JavaObject{T}}, field::JField) where T
     fieldType = jimport(gettype(field))
-    jfieldID = JNI.FromReflectedField(field)
-    jfieldID==C_NULL && geterror(true)
-    _jfield(metaclass(T), jfieldID, fieldType)
+    JNI.FromReflectedField(field)
 end
 
-function jfield(obj::JavaObject, field::AbstractString, fieldType::Type)
-    assertroottask_or_goodenv() && assertloaded()
-    jfieldID  = JNI.GetFieldID(Ptr(metaclass(obj)), String(field), signature(fieldType))
-    jfieldID==C_NULL && geterror(true)
-    _jfield(obj, jfieldID, fieldType)
+function get_field_id(obj::JavaObject, field::AbstractString, fieldType::Type)
+    JNI.GetFieldID(Ptr(metaclass(obj)), String(field), signature(fieldType))
 end
 
-function jfield(obj::JavaObject, field::JField)
-    assertroottask_or_goodenv() && assertloaded()
+function get_field_id(obj::JavaObject, field::JField)
     fieldType = jimport(gettype(field))
-    jfieldID = JNI.FromReflectedField(field)
-    jfieldID==C_NULL && geterror(true)
-    _jfield(obj, jfieldID, fieldType)
+    JNI.FromReflectedField(field)
 end
 
 # JField invoke
 (f::JField)(obj) = jfield(obj, f)
 
-for (x, y, z) in [(:jboolean, :(JNI.GetBooleanField), :(JNI.GetStaticBooleanField)),
-                  (:jchar,    :(JNI.GetCharField),    :(JNI.GetStaticCharField))   ,
-                  (:jbyte,    :(JNI.GetByteField),    :(JNI.GetStaticBypeField))   ,
-                  (:jshort,   :(JNI.GetShortField),   :(JNI.GetStaticShortField))  ,
-                  (:jint,     :(JNI.GetIntField),     :(JNI.GetStaticIntField))    ,
-                  (:jlong,    :(JNI.GetLongField),    :(JNI.GetStaticLongField))   ,
-                  (:jfloat,   :(JNI.GetFloatField),   :(JNI.GetStaticFloatField))  ,
-                  (:jdouble,  :(JNI.GetDoubleField),  :(JNI.GetStaticDoubleField)) ]
-
-    m = quote
-        function _jfield(obj, jfieldID::Ptr{Nothing}, fieldType::Type{$(x)})
-            callmethod = ifelse( typeof(obj)<:JavaObject, $y , $z )
-            result = callmethod(Ptr(obj), jfieldID)
-            result==C_NULL && geterror()
-            return convert_result(fieldType, result)
-        end
-    end
-    eval(m)
-end
-
 function _jfield(obj, jfieldID::Ptr{Nothing}, fieldType::Type)
-    callmethod = ifelse( typeof(obj)<:JavaObject, JNI.GetObjectField , JNI.GetStaticObjectField )
-    result = callmethod(Ptr(obj), jfieldID)
+    result = _jnifield(obj, jfieldID, fieldType)
     result==C_NULL && geterror()
     return convert_result(fieldType, result)
 end
 
-#Generate these methods to satisfy ccall's compile time constant requirement
-#_jcall for primitive and Nothing return types
-for (x, y, z) in [(:jboolean, :(JNI.CallBooleanMethodA), :(JNI.CallStaticBooleanMethodA)),
-                  (:jchar,    :(JNI.CallCharMethodA),    :(JNI.CallStaticCharMethodA))   ,
-                  (:jbyte,    :(JNI.CallByteMethodA),    :(JNI.CallStaticByteMethodA))   ,
-                  (:jshort,   :(JNI.CallShortMethodA),   :(JNI.CallStaticShortMethodA))  ,
-                  (:jint,     :(JNI.CallIntMethodA),     :(JNI.CallStaticIntMethodA))    ,
-                  (:jlong,    :(JNI.CallLongMethodA),    :(JNI.CallStaticLongMethodA))   ,
-                  (:jfloat,   :(JNI.CallFloatMethodA),   :(JNI.CallStaticFloatMethodA))  ,
-                  (:jdouble,  :(JNI.CallDoubleMethodA),  :(JNI.CallStaticDoubleMethodA)) ,
-                  (:jvoid,    :(JNI.CallVoidMethodA),    :(JNI.CallStaticVoidMethodA))   ]
-    m = quote
-        function _jcall(obj, jmethodId::Ptr{Nothing}, callmethod::Ptr{Nothing}, rettype::Type{$(x)},
-                        argtypes::Tuple, args...)
-            if callmethod == C_NULL #!
-                callmethod = ifelse( typeof(obj)<:JavaObject, $y , $z )
-            end
-            @assert callmethod != C_NULL
-            @assert jmethodId != C_NULL
-            isnull(obj) && throw(JavaCallError("Attempt to call method on Java NULL"))
-            savedArgs, convertedArgs = convert_args(argtypes, args...)
-            GC.@preserve savedArgs begin
-                result = callmethod(Ptr(obj), jmethodId, Array{JNI.jvalue}(jvalue.(convertedArgs)))
-            end
-            deleteref.(filter(x->isa(x,JavaObject),convertedArgs))
-            result==C_NULL && geterror()
-            result == nothing && (return)
-            return convert_result(rettype, result)
-        end
-    end
-    eval(m)
-end
-
-#_jcall for Object return types
-#obj -- receiver - Class pointer or object prointer
-#jmethodId -- Java method ID
-#callmethod -- the C method pointer to call
-function _jcall(obj, jmethodId::Ptr{Nothing}, callmethod::Union{Function,Ptr{Nothing}}, rettype::Type, argtypes::Tuple,
-                args...)
-    if callmethod == C_NULL
-        callmethod = ifelse(typeof(obj)<:JavaObject,
-                            JNI.CallObjectMethodA  ,
-                            JNI.CallStaticObjectMethodA)
-    end
-    @assert callmethod != C_NULL
-    @assert jmethodId != C_NULL
-    isnull(obj) && error("Attempt to call method on Java NULL")
+function _jcall(obj, jmethodId, callmethod, rettype, argtypes, args...)
     savedArgs, convertedArgs = convert_args(argtypes, args...)
     GC.@preserve savedArgs begin
-        result = callmethod(Ptr(obj), jmethodId, Array{JNI.jvalue}(jvalue.(convertedArgs)))
+        result = _jnicall(obj, jmethodId, rettype, argtypes, jvalue.(convertedArgs))
     end
     deleteref.(filter(x->isa(x,JavaObject),convertedArgs))
     result==C_NULL && geterror()
     return convert_result(rettype, result)
 end
 
+#Generate these methods to satisfy ccall's compile time constant requirement
+for (x, name) in [(:Type,             "Object"),
+                  (:(Type{jboolean}), "Boolean"),
+                  (:(Type{jchar}),    "Char"   ),
+                  (:(Type{jbyte}),    "Byte"   ),
+                  (:(Type{jshort}),   "Short"  ),
+                  (:(Type{jint}),     "Int"    ),
+                  (:(Type{jlong}),    "Long"   ),
+                  (:(Type{jfloat}),   "Float"  ),
+                  (:(Type{jdouble}),  "Double" ),
+                  (:(Type{jvoid}),    "Void"   )]
+    for (t, cstr, fstr) in [(:JavaObject,    "Call$(name)MethodA",      "Get$(name)Field"),
+                            (:JavaMetaClass, "CallStatic$(name)MethodA", "GetStatic$(name)Field")]
+        callmethod = :(JNI.$(Symbol(cstr)))
+        fieldmethod = :(JNI.$(Symbol(fstr)))
+        m = quote
+            function _jnicall(obj::T, jmethodId::Ptr{Nothing}, rettype::$x,
+                            argtypes::Tuple, args) where T <: $t
+                $callmethod(Ptr(obj), jmethodId, Array{JNI.jvalue}(args))
+            end
+            function _jnifield(obj::T, jfieldID::Ptr{Nothing}, fieldType::$x) where T <: $t
+                $fieldmethod(Ptr(obj), jfieldID)
+            end
+        end
+        eval(m)
+    end
+end
 
 global const _jmc_cache = [ Dict{Symbol, JavaMetaClass}() ]
 
@@ -557,33 +519,17 @@ function method_signature(rettype, argtypes...)
     return String(take!(s))
 end
 
-
 #get the JNI signature string for a given type
-function signature(arg::Type)
-    if arg === jboolean
-        return "Z"
-    elseif arg === jbyte
-        return "B"
-    elseif arg === jchar
-        return "C"
-    elseif arg === jshort
-        return "S"
-    elseif arg === jint
-        return "I"
-    elseif arg === jlong
-        return "J"
-    elseif arg === jfloat
-        return "F"
-    elseif arg === jdouble
-        return "D"
-    elseif arg === jvoid
-        return "V"
-    elseif arg <: Array
-        dims = "[" ^ ndims(arg)
-        return string(dims, signature(eltype(arg)))
-    end
-end
-
+signature(::Type{jboolean}) = "Z"
+signature(::Type{jbyte}) = "B"
+signature(::Type{jchar}) = "C"
+signature(::Type{jshort}) = "S"
+signature(::Type{jint}) = "I"
+signature(::Type{jlong}) = "J"
+signature(::Type{jfloat}) = "F"
+signature(::Type{jdouble}) = "D"
+signature(::Type{jvoid}) = "V"
+signature(::Type{Array{T,N}}) where {T,N} = string("[" ^ N, signature(T))
 signature(arg::Type{JavaObject{T}}) where {T} = string("L", javaclassname(T), ";")
 signature(arg::Type{JavaObject{T}}) where {T <: AbstractVector} = JavaCall.javaclassname(T)
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -410,10 +410,12 @@ for (x, name) in [(:Type,             "Object"),
                   (:(Type{jfloat}),   "Float"  ),
                   (:(Type{jdouble}),  "Double" ),
                   (:(Type{jvoid}),    "Void"   )]
-    for (t, cstr, fstr) in [(:JavaObject,    "Call$(name)MethodA",      "Get$(name)Field"),
-                            (:JavaMetaClass, "CallStatic$(name)MethodA", "GetStatic$(name)Field")]
-        callmethod = :(JNI.$(Symbol(cstr)))
-        fieldmethod = :(JNI.$(Symbol(fstr)))
+    for (t, callprefix, getprefix) in [
+        (:JavaObject,    :(JNI.Call), :(JNI.Get) ),
+        (:JavaMetaClass, :(JNI.CallStatic), :(JNI.GetStatic) )
+    ]
+        callmethod = Symbol(callprefix, name, :MethodA)
+        fieldmethod = Symbol(getprefix, name, :Field)
         m = quote
             function _jfield(obj::T, jfieldID::Ptr{Nothing}, fieldType::$x) where T <: $t
                 result = $fieldmethod(Ptr(obj), jfieldID)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,36 @@ end
     @test typeof(h)==jint
 end
 
+@testset "method_styles_1" begin
+    method_dict(x) = map(listmethods(x)) do m
+        param_t = Tuple(JavaCall.jimport.(getparametertypes(m)))
+        ret_t = JavaCall.jimport(getreturntype(m))
+        (getname(m), ret_t, param_t) => m
+    end |> Dict
+
+
+    jmath = @jimport java.lang.Math 
+    methods = method_dict(jmath)
+    for (method_key, params) in [(("hypot", jdouble, (jdouble, jdouble)), (2.0, 3.0)),
+                                 (("getExponent", jint, (jfloat,)), (1.0))
+                                ]
+        res = jcall(jmath, method_key..., params...)
+        @test res == methods[method_key](jmath, params...)
+        @test res == jcall(jmath, methods[method_key], params...)
+    end
+
+    jnu = @jimport java.net.URL
+    gurl = jnu((JString,), "https://en.wikipedia.org")
+    methods = method_dict(gurl)
+    for (method_key, params) in [(("getProtocol", JString, ()), ()),
+                                 (("getHost", JString, ()), ())
+                                ]
+        res = jcall(gurl, method_key..., params...)
+        @test res == methods[method_key](gurl, params...)
+        @test res == jcall(gurl, methods[method_key], params...)
+    end
+end
+
 @testset "exceptions_1" begin
     j_u_arrays = @jimport java.util.Arrays
     j_math = @jimport java.lang.Math
@@ -101,15 +131,27 @@ end
     
     # JavaCall.JavaCallError("Error calling Java: java.lang.ArithmeticException: / by zero")
     @test_throws JavaCall.JavaCallError jcall(j_math, "floorDiv", jint, (jint, jint), 1, 0)
-    @test isnothing(JavaCall.geterror())
+    @test JavaCall.geterror() === nothing
 
     # JavaCall.JavaCallError("Error calling Java: java.lang.ArrayIndexOutOfBoundsException: Array index out of range: -1")
     @test_throws JavaCall.JavaCallError jcall(j_u_arrays, "sort", Nothing, (Array{jint,1}, jint, jint), [10,20], -1, -1)
-    @test isnothing(JavaCall.geterror())
+    @test JavaCall.geterror() === nothing
 
     # JavaCall.JavaCallError("Error calling Java: java.lang.IllegalArgumentException: fromIndex(1) > toIndex(0)")
     @test_throws JavaCall.JavaCallError jcall(j_u_arrays, "sort", Nothing, (Array{jint,1}, jint, jint), [10,20], 1, 0)
-    @test isnothing(JavaCall.geterror())
+    @test JavaCall.geterror() === nothing
+
+    # JavaCall.JavaCallError("Error calling Java: java.lang.InstantiationException: java.util.AbstractCollection")
+    @test_throws JavaCall.JavaCallError (@jimport java.util.AbstractCollection)()
+    @test JavaCall.geterror() === nothing
+
+    # JavaCall.JavaCallError("Error calling Java: java.lang.NoClassDefFoundError: java/util/Lis")
+    @test_throws JavaCall.JavaCallError (@jimport java.util.Lis)()
+    @test JavaCall.geterror() === nothing
+
+    # JavaCall.JavaCallError("Error calling Java: java.lang.NoSuchMethodError: <init>")
+    @test_throws JavaCall.JavaCallError (@jimport java.util.ArrayList)((jboolean,), true)
+    @test JavaCall.geterror() === nothing
 end
 
 @testset "fields_1" begin
@@ -137,10 +179,10 @@ end
     @test jcall(jfield(j_l_bool, "FALSE", j_l_bool), "booleanValue", jboolean, ()) == false
 
     @test jfield(@jimport(java.text.NumberFormat), "INTEGER_FIELD", jint) == 0
+    @test jfield(@jimport(java.util.logging.Logger), "GLOBAL_LOGGER_NAME", JString ) == "global"
     locale = @jimport java.util.Locale
     lc = jfield(locale, "CANADA", locale)
-    @test jcall(lc, "getCountry", JString, ()) == "CA" #TODO: remove?
-    #Instance field access
+    @test jcall(lc, "getCountry", JString, ()) == "CA"
 end
 
 #Test NULL
@@ -222,10 +264,6 @@ end
     t=JTest(())
     inner = TestInner((JTest,), t)
     @test jcall(inner, "innerString", JString, ()) == "from inner"
-    #Disabled for now. Need to verify stability
-    @test jfield(@jimport(java.util.logging.Logger), "GLOBAL_LOGGER_NAME", JString ) == "global"
-    @test jfield(t, "integerField", jint) == 100
-    @test jfield(t, "stringField", JString) == "A STRING"
 end
 
 # Test Memory allocation and de-allocatios


### PR DESCRIPTION
The main purpose of this PR is to make it easier to extend JavaCall with types that e.g. need special cleanup, define a `signature` method, etc. (see #144).

Since the relevant logic to handle the core call through `JNI` was spread out, discrepancies had crept into the codebase:

https://github.com/JuliaInterop/JavaCall.jl/blob/7973dc760fc8b3fdd07baf763cf27b515d199e88/src/core.jl#L485

https://github.com/JuliaInterop/JavaCall.jl/blob/7973dc760fc8b3fdd07baf763cf27b515d199e88/src/core.jl#L458

So:

```
julia> jcall(JavaObject{Symbol("java.util.HashMap")}(C_NULL), "toString", JString, ())
ERROR: Attempt to call method on Java NULL
Stacktrace:
...

julia> jcall(JavaObject{Symbol("java.util.HashMap")}(C_NULL), "isEmpty", jboolean, ())
ERROR: JavaCall.JavaCallError("Attempt to call method on Java NULL")
Stacktrace:
...
```

I believe this discrepancy arose because the central logic for setting up and "tearing down" a call (including error checking) is fragmented. For this reason I don't feel comfortable adding the functionality in #144 before this logic has been consolidated e.g. through this PR.

My goal in this PR is therefore to more or less only have one place in `core.jl` where we:
- Convert arguments
- Use `GC.@preserve`
- Tear down temporary objects
- Check errors
- Convert result

for a Java method call.
