### PR TITLE
Julia 1.x is no longer LTS (and no mentioned version supported)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Documentation is available at http://juliainterop.github.io/JavaCall.jl
 
 ## Versions
 
-* 0.7 branch is currently being maintained for bug fixes only
-* master branch is currently proposed to be v0.8.0
+* 0.7 branch is currently being maintained for bug fixes only.
+* master branch is currently proposed to be v0.8.0.
 
 ## Non-Windows Operating Systems
 
-_JavaCall and its derivatives do not work correctly on Julia 1.1 and Julia 1.2. On Julia 1.3, please set the environment variable `JULIA_COPY_STACKS`. On 1.1 and 1.2, and on 1.3 without `JULIA_COPY_STACKS` set, you may see segfaults or incorrect results. This is typically due to stack corruption. The Julia long-term-support version of 1.0.x continues to work correctly as before._
+_JavaCall and its derivatives do not work correctly on Julia 1.1 and Julia 1.2. On Julia 1.3, please set the environment variable `JULIA_COPY_STACKS`. On 1.1 and 1.2, and on 1.3 without `JULIA_COPY_STACKS` set, you may see segfaults or incorrect results. This is typically due to stack corruption. The Julia 1.0.x continues to work correctly as before._
 
 For Julia pre-1.5, consider the [RootTaskRepl.jl](https://github.com/mkitti/RootTaskREPL.jl) package. With RootTaskREPL.jl, JavaCall is able to execute fine without the need of `JULIA_COPY_STACKS=1` with the exception of `@async` calls. Starting with the Julia 1.5, the REPL backend now runs on the root Task by default.
 


### PR DESCRIPTION
Since Windows doesn't need env var hack, was it never affected, and works in all (current) Julia versions? For other platforms, does any (with or) without a hack?