### PR TITLE
Add prototype jcall macro

### DIFF
--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -11,7 +11,7 @@ export JavaObject, JavaMetaClass, JNIVector,
        jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble, jvoid,
        JObject, JClass, JMethod, JConstructor, JField, JString,
        JavaRef, JavaLocalRef, JavaGlobalRef, JavaNullRef,
-       @jimport, jcall, jfield, jlocalframe, isnull,
+       @jimport, @jcall, jcall, jfield, jlocalframe, isnull,
        getname, getclass, listmethods, getreturntype, getparametertypes, classforname,
        listfields, gettype,
        narrow
@@ -40,6 +40,7 @@ include("core.jl")
 include("convert.jl")
 include("reflect.jl")
 include("jniarray.jl")
+include("jcall_macro.jl")
 
 Base.@deprecate_binding jnifunc JavaCall.JNI.jniref[]
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -428,6 +428,8 @@ function jfield(ref, field::AbstractString)
     _jfield(_jcallable(ref), jfieldID, fieldType)
 end
 
+jfield(ref, field::Symbol) = jfield(ref, String(field))
+
 function get_field_id(typ::Type{JavaObject{T}}, field::AbstractString, fieldType::Type) where T
     @checknull JNI.GetStaticFieldID(Ptr(metaclass(T)), String(field), signature(fieldType))
 end

--- a/src/jcall_macro.jl
+++ b/src/jcall_macro.jl
@@ -2,8 +2,8 @@ macro jcall(expr)
     return jcall_macro_lower(jcall_macro_parse(expr)...)
 end
 
-function jcall_macro_lower(func, rettype, types, args, nreq)
-    @debug "args: " func rettype types args nreq
+function jcall_macro_lower(func, rettype, types, args)
+    @debug "args: " func rettype types args
     jtypes = Expr(:tuple, esc.(types)...)
     jargs = Expr(:tuple, esc.(args)...)
     jret = esc(rettype)
@@ -84,19 +84,7 @@ function jcall_macro_parse(expr::Expr)
     for i in argstart:length(callargs)
         pusharg!(callargs[i])
     end
-    # Do we need this in JavaCall?
-    # add any varargs if necessary
-    nreq = 0
-    if !isnothing(varargs)
-        if length(args) == 0
-            throw(ArgumentError("C ABI prohibits vararg without one required argument"))
-        end
-        nreq = length(args)
-        for a in varargs
-            pusharg!(a)
-        end
-    end
 
-    return func, rettype, types, args, nreq
+    return func, rettype, types, args
 end
 

--- a/src/jcall_macro.jl
+++ b/src/jcall_macro.jl
@@ -1,0 +1,95 @@
+macro jcall(expr)
+    return jcall_macro_lower(jcall_macro_parse(expr)...)
+end
+
+function jcall_macro_lower(func, rettype, types, args, nreq)
+    @info "args: " func rettype types args nreq func.head func.args
+    obj = func.args[2]
+    if obj isa Expr && obj.head == :.
+        obj = quote
+            jfield($(obj.args[1]), string($(obj.args[2])))
+        end
+    end
+    f = string(func.args[1].value)
+    jtypes = Expr(:tuple, types...)
+    jret = rettype
+    quote
+        jcall($(esc(obj)), $f, $jret, $jtypes, $args...)
+    end
+end
+
+# @jcall implementation, based on Base.@ccall
+"""
+    jcall_macro_parse(expression)
+
+`jcall_macro_parse` is an implementation detail of `@jcall
+it takes an expression like `:(printf("%d"::Cstring, value::Cuint)::Cvoid)`
+returns: a tuple of `(function_name, return_type, arg_types, args)`
+The above input outputs this:
+    (:printf, :Cvoid, [:Cstring, :Cuint], ["%d", :value])
+"""
+function jcall_macro_parse(expr::Expr)
+    # setup and check for errors
+    if !Meta.isexpr(expr, :(::))
+        throw(ArgumentError("@jcall needs a function signature with a return type"))
+    end
+    rettype = expr.args[2]
+
+    call = expr.args[1]
+    if !Meta.isexpr(call, :call)
+        throw(ArgumentError("@jcall has to take a function call"))
+    end
+
+    # get the function symbols
+    func = let f = call.args[1]
+        if Meta.isexpr(f, :.)
+            :(($(f.args[2]), $(f.args[1])))
+        elseif Meta.isexpr(f, :$)
+            f
+        elseif f isa Symbol
+            QuoteNode(f)
+        else
+            throw(ArgumentError("@jcall function name must be a symbol, a `.` node (e.g. `libc.printf`) or an interpolated function pointer (with `\$`)"))
+        end
+    end
+
+    # detect varargs
+    varargs = nothing
+    argstart = 2
+    callargs = call.args
+    if length(callargs) >= 2 && Meta.isexpr(callargs[2], :parameters)
+        argstart = 3
+        varargs = callargs[2].args
+    end
+
+    # collect args and types
+    args = []
+    types = []
+
+    function pusharg!(arg)
+        if !Meta.isexpr(arg, :(::))
+            throw(ArgumentError("args in @jcall need type annotations. '$arg' doesn't have one."))
+        end
+        push!(args, arg.args[1])
+        push!(types, arg.args[2])
+    end
+
+    for i in argstart:length(callargs)
+        pusharg!(callargs[i])
+    end
+    # Do we need this in JavaCall?
+    # add any varargs if necessary
+    nreq = 0
+    if !isnothing(varargs)
+        if length(args) == 0
+            throw(ArgumentError("C ABI prohibits vararg without one required argument"))
+        end
+        nreq = length(args)
+        for a in varargs
+            pusharg!(a)
+        end
+    end
+
+    return func, rettype, types, args, nreq
+end
+

--- a/test/jcall_macro.jl
+++ b/test/jcall_macro.jl
@@ -1,0 +1,55 @@
+using Test
+using JavaCall
+
+@testset "jcall macro" begin
+    JavaCall.isloaded() || JavaCall.init(["-Djava.class.path=$(@__DIR__)"])
+    System = @jimport java.lang.System
+    version_from_macro = @jcall System.getProperty("java.version"::JString)::JString
+    version_from_func = jcall(System, "getProperty", JString, (JString,), "java.version")
+    @test version_from_macro == version_from_func
+    @test "bar" == @jcall System.getProperty("foo"::JString, "bar"::JString)::JString
+    @test 0x00 == @jcall System.out.checkError()::jboolean
+    rettype = jboolean
+    @test 0x00 == @jcall System.out.checkError()::rettype
+    jstr = JString
+    @test version_from_func == @jcall System.getProperty("java.version"::jstr)::jstr
+
+    T = @jimport Test
+    @test 10 == @jcall T.testShort(10::jshort)::jshort
+    @test 10 == @jcall T.testInt(10::jint)::jint
+    @test 10 == @jcall T.testLong(10::jlong)::jlong
+    @test typemax(jint) == @jcall T.testInt(typemax(jint)::jint)::jint
+    @test typemax(jlong) == @jcall T.testLong(typemax(jlong)::jlong)::jlong
+    @test "Hello Java" == @jcall T.testString("Hello Java"::JString)::JString
+    @test Float64(10.02) == @jcall T.testDouble(10.02::jdouble)::jdouble
+    @test Float32(10.02) == @jcall T.testFloat(10.02::jfloat)::jfloat
+    @test floatmax(jdouble) == @jcall T.testDouble(floatmax(jdouble)::jdouble)::jdouble
+    @test floatmax(jfloat) == @jcall T.testFloat(floatmax(jfloat)::jfloat)::jfloat
+    c=JString(C_NULL)
+    @test isnull(c)
+    @test "" == @jcall T.testString(c::JString)::JString
+    a = rand(10^7)
+    @test [@jcall(T.testDoubleArray(a::Array{jdouble,1})::jdouble)
+           for i in 1:10][1] ≈ sum(a)
+    a = nothing
+
+    jlm = @jimport "java.lang.Math"
+    @test 1.0 ≈ @jcall jlm.sin((pi/2)::jdouble)::jdouble
+    @test 1.0 ≈ @jcall jlm.min(1::jdouble, 2::jdouble)::jdouble
+    @test 1 == @jcall jlm.abs((-1)::jint)::jint
+
+    @testset "jcall macro instance_methods_1" begin
+        jnu = @jimport java.net.URL
+        gurl = @jcall jnu("https://en.wikipedia.org"::JString)::jnu
+        @test "en.wikipedia.org"== @jcall gurl.getHost()::JString
+        jni = @jimport java.net.URI
+        guri = @jcall gurl.toURI()::jni
+        @test typeof(guri)==jni
+
+        h=@jcall guri.hashCode()::jint
+        @test typeof(h)==jint
+    end
+
+    jlist = @jimport java.util.ArrayList
+    @test 0x01 == @jcall jlist().add(JObject(C_NULL)::JObject)::jboolean
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -438,6 +438,8 @@ end
     end
 end
 
+include("jcall_macro.jl")
+
 end
 
 # Test downstream dependencies


### PR DESCRIPTION
Prototype `@jcall` macro:

```julia
julia> using JavaCall; JavaCall.init()

julia> System = @jimport java.lang.System
JavaObject{Symbol("java.lang.System")}

julia> @jcall System.out.println("Hello from Java!!"::JString)::Nothing
┌ Info: args: 
│   func = :((:println, System.out))
│   rettype = :Nothing
│   types =
│    1-element Vector{Any}:
│     :JString
│   args =
│    1-element Vector{Any}:
│     "Hello from Java!!"
│   nreq = 0
│   func.head = :tuple
│   func.args =
│    2-element Vector{Any}:
│     :(:println)
└     :(System.out)
Hello from Java!!

julia> Math = @jimport java.lang.Math
JavaObject{Symbol("java.lang.Math")}

julia> @jcall Math.cos(0.0::jdouble)::jdouble
┌ Info: args: 
│   func = :((:cos, Math))
│   rettype = :jdouble
│   types =
│    1-element Vector{Any}:
│     :jdouble
│   args =
│    1-element Vector{Any}:
│     0.0
│   nreq = 0
│   func.head = :tuple
│   func.args =
│    2-element Vector{Any}:
│     :(:cos)
└     :Math
1.0

julia> @jcall Math.acos((-0.0)::jdouble)::jdouble
┌ Info: args: 
│   func = :((:acos, Math))
│   rettype = :jdouble
│   types =
│    1-element Vector{Any}:
│     :jdouble
│   args =
│    1-element Vector{Any}:
│     -0.0
│   nreq = 0
│   func.head = :tuple
│   func.args =
│    2-element Vector{Any}:
│     :(:acos)
└     :Math
1.5707963267948966
```