### PR TITLE
Fix JNI array leaking by freeing the memory after conversion

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -155,6 +155,8 @@ function convert_result(rettype::Type{Array{JavaObject{T},1}}, result) where T
         a=JNI.GetObjectArrayElement(result, i-1)
         ret[i] = JavaObject{T}(a)
     end
+    
+    JNI.DeleteLocalRef(result)
     return ret
 end
 
@@ -169,6 +171,8 @@ function convert_result(rettype::Type{Array{T,1}}, result) where T
         a=JNI.GetObjectArrayElement(result, i-1)
         ret[i] = convert_result(T, a)
     end
+
+    JNI.DeleteLocalRef(result)
     return ret
 end
 
@@ -191,6 +195,8 @@ function convert_result(rettype::Type{Array{JavaObject{T},2}}, result) where T
             ret[i, j] = JavaObject{T}(x)
         end
     end
+
+    JNI.DeleteLocalRef(result)
     return ret
 end
 
@@ -211,6 +217,8 @@ function convert_result(rettype::Type{Array{T,2}}, result) where T
         @assert(sz_a == sz_1, "Size of $(i)th subrarray is $sz_a, but size of the 1st subarray was $sz_1")
         ret[i, :] = convert_result(Vector{T}, a)
     end
+
+    JNI.DeleteLocalRef(result)
     return ret
 end
 


### PR DESCRIPTION
It was observed that JavaCall was leaking memory when getting arrays of objects from Java. This is due to the fact that arrays from Java are converted into Julia arrays by copying the elements over from the Java array, but the Java array is subsequently not freed from memory, causing a leak as at the end of the Julia code the pointer is garbage collected.  In #135  essentially the same leak was fixed, but only for primitive arrays, not arrays of Java objects, etc. This PR aims to solve the issue for the remaining cases.