### PR TITLE
Inverted listing of  Julia version compatibility in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ Hello World
 * 0.7 branch is currently being maintained for bug fixes only
 * master branch is currently proposed to be v0.8.0
 
-## Julia version compatability
+## Julia version compatibility
 
-JavaCall should continue to work with Julia 1.0.x (formerly a long term support version of Julia).
-
-JavaCall and its dependents do not work correctly on Julia 1.1 and Julia 1.2.  On Julia 1.1 and 1.2, you may see segfaults or incorrect results. This is typically due to stack corruption.
+Julia 1.3.0 through Julia 1.6.2 are tested and guaranteed to work on Linux, macOS, and Windows via continuous integration. Julia 1.6.2 and newer should work on Linux and Windows. The `JULIA_COPY_STACKS` environment variable should be set to `1` on macOS and Linux, but not Windows.
 
 For Julia pre-1.5, consider the [RootTaskRepl.jl](https://github.com/mkitti/RootTaskREPL.jl) package. With RootTaskREPL.jl, JavaCall is able to execute fine without the need of `JULIA_COPY_STACKS=1` with the exception of `@async` calls. Starting with the Julia 1.5, the REPL backend now runs on the root Task by default.
 
-Julia 1.3.0 through Julia 1.6.2 are tested and guaranteed to work on Linux, macOS, and Windows via continuous integration. Julia 1.6.2 and newer should work on Linux and Windows. The `JULIA_COPY_STACKS` environment variable should be set to `1` on macOS and Linux, but not Windows.
+JavaCall and its dependents do not work correctly on Julia 1.1 and Julia 1.2.  On Julia 1.1 and 1.2, you may see segfaults or incorrect results. This is typically due to stack corruption.
+
+JavaCall should continue to work with Julia 1.0.x (formerly a long term support version of Julia).
 
 ## Apple macOS
 


### PR DESCRIPTION
In the "Julia version compatibility" let's first list compatibility with the latest versions of Julia, and then go back in the history of older versions, otherwise one read "it doesn't work with Julia 1.2" and think "gosh, this package is so old and unmaintained !"